### PR TITLE
Fix AIC/BIC multi-model bugs

### DIFF
--- a/R/emaxnls-methods.R
+++ b/R/emaxnls-methods.R
@@ -321,22 +321,20 @@ AIC.emaxnls <- function(object, ..., k = 2) {
     emaxnls_mods <- emaxnls_mods[converged]
     mod_names <- mod_names[converged]
   }
-  if (length(emaxnls_mods) == 1L) return(stats::AIC(.get_nls(object))) 
-  nls_mods <- .map(
-    .x = emaxnls_mods, 
-    .f = function(mm) {
-      nls_mod <- .get_nls(mm)
-      if (is.null(nls_mod)) nls_mod <- .nls_null()
-      nls_mod
-    }
-  )
+  if (length(emaxnls_mods) == 1L) {
+    ll <- stats::logLik(emaxnls_mods[[1L]])
+    return(as.numeric(-2 * ll + k * attr(ll, "df")))
+  }
   aic_vals <- unlist(.map(
-    .x = nls_mods,
-    .f = stats::AIC
+    .x = emaxnls_mods,
+    .f = function(mm) {
+      ll <- stats::logLik(mm)
+      as.numeric(-2 * ll + k * attr(ll, "df"))
+    }
   ))
   df_vals <- unlist(.map(
     .x = emaxnls_mods,
-    .f = function(mm) evalq(stats::df.residual(model), envir = mm$env)
+    .f = function(mm) attr(stats::logLik(mm), "df")
   ))
   out <- data.frame(df = df_vals, AIC = aic_vals, row.names = mod_names)
   out
@@ -356,22 +354,22 @@ BIC.emaxnls <- function(object, ...) {
     emaxnls_mods <- emaxnls_mods[converged]
     mod_names <- mod_names[converged]
   }
-  if (length(emaxnls_mods) == 1L) return(stats::BIC(.get_nls(object))) 
-  nls_mods <- .map(
-    .x = emaxnls_mods, 
-    .f = function(mm) {
-      nls_mod <- .get_nls(mm)
-      if (is.null(nls_mod)) nls_mod <- .nls_null()
-      nls_mod
-    }
-  )
+  if (length(emaxnls_mods) == 1L) {
+    ll <- stats::logLik(emaxnls_mods[[1L]])
+    n  <- attr(ll, "nobs")
+    return(as.numeric(-2 * ll + log(n) * attr(ll, "df")))
+  }
   bic_vals <- unlist(.map(
-    .x = nls_mods,
-    .f = stats::BIC
+    .x = emaxnls_mods,
+    .f = function(mm) {
+      ll <- stats::logLik(mm)
+      n  <- attr(ll, "nobs")
+      as.numeric(-2 * ll + log(n) * attr(ll, "df"))
+    }
   ))
   df_vals <- unlist(.map(
     .x = emaxnls_mods,
-    .f = function(mm) evalq(stats::df.residual(model), envir = mm$env)
+    .f = function(mm) attr(stats::logLik(mm), "df")
   ))
   out <- data.frame(df = df_vals, BIC = bic_vals, row.names = mod_names)
   out


### PR DESCRIPTION
Fixes #26, #27, #28.

## Changes

Three related bugs in `AIC.emaxnls` and `BIC.emaxnls`:

### Bug 1: Wrong object after filtering (#26)
After filtering out non-converging models, the single-model fast-path used the original `object` argument (which may be the dropped non-converging model) instead of `emaxnls_mods[[1L]]`.

### Bug 2: k parameter ignored for single-model case (#27)
`AIC(mod, k=3)` was silently using `k=2` because the fast-path delegated to `stats::AIC(.get_nls(object))` without forwarding `k`. The fix computes AIC directly from `logLik`.

### Bug 3: df column showed residual df, not parameter count (#28)
The multi-model comparison table populated `df` with residual degrees of freedom (`n - p`) from `df.residual()`, inconsistent with `AIC.emaxlogistic` and the `stats::AIC()` convention of showing the number of parameters. Fixed to use `attr(logLik(mm), "df")`.