### PR TITLE
Fix na.action parameter

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -111,7 +111,7 @@ emax_nls_options <- function(optim_method = "gauss",
                              optim_control = NULL,
                              quiet = FALSE,
                              weights = NULL,
-                             na.action = options("na.action")) {
+                             na.action = getOption("na.action")) {
   .emax_nls_options(
     optim_method = optim_method,
     optim_control = optim_control,
@@ -504,7 +504,7 @@ emax_logistic <- function(structural_model,
 emax_logistic_options <- function(optim_method = "gauss",
                                   optim_control = NULL,
                                   quiet = FALSE,
-                                  na.action = options("na.action"),
+                                  na.action = getOption("na.action"),
                                   max_iter = 25,
                                   tol = 1e-6) {
   .emax_logistic_options(

--- a/R/emaxlogistic-class.R
+++ b/R/emaxlogistic-class.R
@@ -15,7 +15,8 @@
 
   if (is.null(opts)) opts <- emax_logistic_options()
 
-  tmp <- .construct_design(structural_model, covariate_model, data)
+  tmp <- .construct_design(structural_model, covariate_model, data,
+                           na.action = opts$na.action)
 
   obj <- list(
     formula = list(

--- a/R/emaxlogistic-options.R
+++ b/R/emaxlogistic-options.R
@@ -14,6 +14,9 @@
     if (optim_method == "levenberg") optim_control <- minpack.lm::nls.lm.control()
   }
 
+  # Resolve na.action to a function: accept a character name or a function
+  if (is.character(na.action)) na.action <- match.fun(na.action)
+
   opts <- list(
     optim_method = optim_method,
     optim_control = optim_control,

--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -70,7 +70,7 @@
 }
 
 .construct_design <- function(structural_model, covariate_model, data,
-                              na.action = na.pass) {
+                              na.action = stats::na.pass) {
 
   # construct flat formula 
   ss <- deparse(structural_model)

--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -12,7 +12,8 @@
   
   if (is.null(opts)) opts <- emax_nls_options()
 
-  tmp <- .construct_design(structural_model, covariate_model, data)
+  tmp <- .construct_design(structural_model, covariate_model, data,
+                           na.action = opts$na.action)
 
   obj <- list(
     formula = list( 
@@ -68,7 +69,8 @@
   stop("invalid covariate model", call. = FALSE)
 }
 
-.construct_design <- function(structural_model, covariate_model, data) {
+.construct_design <- function(structural_model, covariate_model, data,
+                              na.action = na.pass) {
 
   # construct flat formula 
   ss <- deparse(structural_model)
@@ -83,8 +85,13 @@
     ff <- stats::as.formula(paste(ss, cc, sep = "+"))
   }
 
+  # Use model.frame to apply the na.action consistently across all variables
+  # (including the response) before building the model matrix. This prevents
+  # a dimension mismatch between the model matrix and the response column.
+  mf <- stats::model.frame(ff, data = data, na.action = na.action)
+
   # model matrix
-  mm <- stats::model.matrix(ff, data)
+  mm <- stats::model.matrix(ff, data = mf)
 
   preds <- all.vars(ff)        # variables required, including response
   terms <- colnames(mm)[-1]    # terms in the model, dropping intercept
@@ -95,7 +102,7 @@
 
   lookup <- .tibble(var_name = preds[index], term = terms)
   design <- stats::setNames(.as_tibble(mm), terms)
-  design[[preds[1]]] <- data[[preds[1]]]
+  design[[preds[1]]] <- mf[[preds[1]]]
      
   return(list(design = design, lookup = lookup))
 }

--- a/R/emaxnls-options.R
+++ b/R/emaxnls-options.R
@@ -12,6 +12,9 @@
     if (optim_method == "levenberg") optim_control <- minpack.lm::nls.lm.control()
   }
 
+  # Resolve na.action to a function: accept a character name or a function
+  if (is.character(na.action)) na.action <- match.fun(na.action)
+
   opts <- list(
     optim_method = optim_method,
     optim_control = optim_control,

--- a/R/emaxnls-update.R
+++ b/R/emaxnls-update.R
@@ -33,7 +33,9 @@
   covariate_model[[str_param]] <- new
 
   # initial parameter guess for updated model
-  tmp <- .construct_design(structural_model, covariate_model, .get_data(mod))
+  na_action <- .get_options(mod)$na.action
+  tmp <- .construct_design(structural_model, covariate_model, .get_data(mod),
+                           na.action = na_action)
   init <- .guess_init(
     variables = .construct_variables(structural_model, covariate_model, tmp$lookup),
     design = tmp$design
@@ -87,7 +89,9 @@
   covariate_model[[str_param]] <- new
 
   # initial parameter guess for updated model
-  tmp <- .construct_design(structural_model, covariate_model, .get_data(mod))
+  na_action <- .get_options(mod)$na.action
+  tmp <- .construct_design(structural_model, covariate_model, .get_data(mod),
+                           na.action = na_action)
   init <- .guess_init(
     variables = .construct_variables(structural_model, covariate_model, tmp$lookup),
     design = tmp$design

--- a/man/emax_logistic_options.Rd
+++ b/man/emax_logistic_options.Rd
@@ -8,7 +8,7 @@ emax_logistic_options(
   optim_method = "gauss",
   optim_control = NULL,
   quiet = FALSE,
-  na.action = options("na.action"),
+  na.action = getOption("na.action"),
   max_iter = 25,
   tol = 1e-06
 )

--- a/man/emax_nls_options.Rd
+++ b/man/emax_nls_options.Rd
@@ -9,7 +9,7 @@ emax_nls_options(
   optim_control = NULL,
   quiet = FALSE,
   weights = NULL,
-  na.action = options("na.action")
+  na.action = getOption("na.action")
 )
 }
 \arguments{


### PR DESCRIPTION
Fixes #25.

## Changes

### Bug 1: Wrong R idiom
`options("na.action")` returns a **named list** (`list(na.action = "na.omit")`), not a function or character string. Changed to `getOption("na.action")` in both `emax_nls_options()` and `emax_logistic_options()`.

### Bug 2: na.action was never applied
`stats::nls()` does not have a `na.action` argument. The option was stored in `opts$na.action` but never used.

The fix applies `na.action` via `stats::model.frame()` inside `.construct_design()`. Using `model.frame()` ensures the NA handling is consistent across all variables (response + covariates) before the model matrix is built — previously, `model.matrix()` would silently remove rows with NA predictors while the response was added from the full data, causing a dimension mismatch.

The na.action is also now resolved to a function in the option constructors, so downstream code can call it directly.