### PR TITLE
Fix predict() missing residual.scale when se.fit = TRUE

### DIFF
--- a/R/emaxnls-predict.R
+++ b/R/emaxnls-predict.R
@@ -40,12 +40,13 @@
   # compute the standard error
   vcov <- vcov(object)
   df <- summary(object)$df[2]
+  rs <- summary(object)$sigma
   gs <- rowSums((fg$grad %*% vcov) * fg$grad)
   se <- sqrt(gs)
 
   # if the standard error is requested with no 
-  # interval, return list with three components
-  if (interval == "none") return(list(fit = fg$value, se.fit = se, df = df))
+  # interval, return list with four components
+  if (interval == "none") return(list(fit = fg$value, se.fit = se, residual.scale = rs, df = df))
 
   # compute confidence intervals
   alpha <- 1 - level
@@ -57,11 +58,11 @@
   )
 
   # if interval is requested but no standard error, 
-  # return data frame with three colums
+  # return data frame with three columns
   if (se.fit == FALSE) return(ci_fit)
 
   # otherwise, return the list
-  return(list(fit = ci_fit, se.fit = se, df = df))
+  return(list(fit = ci_fit, se.fit = se, residual.scale = rs, df = df))
 }
 
 # function to calculate gradient with respect to model parameters

--- a/tests/testthat/test-emaxlogistic-methods.R
+++ b/tests/testthat/test-emaxlogistic-methods.R
@@ -374,10 +374,10 @@ test_that("simulate() produces binary values in the val column", {
 
 # predict() with se.fit and interval --------------------------------------
 
-test_that("predict(se.fit = TRUE) returns a list with fit, se.fit, and df", {
+test_that("predict(se.fit = TRUE) returns a list with fit, se.fit, residual.scale, and df", {
   pr <- predict(mod_base, se.fit = TRUE)
   expect_type(pr, "list")
-  expect_named(pr, c("fit", "se.fit", "df"))
+  expect_named(pr, c("fit", "se.fit", "residual.scale", "df"))
   expect_true(all(pr$fit > 0 & pr$fit < 1))
   expect_true(is.numeric(pr$se.fit))
   expect_length(pr$df, 1L)

--- a/tests/testthat/test-emaxnls-predict.R
+++ b/tests/testthat/test-emaxnls-predict.R
@@ -18,7 +18,7 @@ test_that("predict with se.fit returns list", {
   pr_vec <- predict(mod)
   pr_lst <- predict(mod, se.fit = TRUE)
   expect_type(pr_lst, "list")
-  expect_named(pr_lst, c("fit", "se.fit", "df"))
+  expect_named(pr_lst, c("fit", "se.fit", "residual.scale", "df"))
   expect_equal(pr_lst$fit, pr_vec)
   expect_true(is.numeric(pr_lst$se))
   expect_true(is.numeric(pr_lst$df))
@@ -114,6 +114,7 @@ test_that(".predict_nls matches default predict method for nls objects", {
 xgx_1 <- list(
   fit = c(0.1452964, 0.1605549, 0.1774132),
   se.fit = c(0.02331904, 0.02490512, 0.02647756),
+  residual.scale = 0.07637093,
   df = 8L
 )
 
@@ -125,6 +126,7 @@ xgx_2 <- list(
     upr = c(0.1990702, 0.2179862, 0.2384706)
   ),
   se.fit = c(0.02331904, 0.02490512, 0.02647756),
+  residual.scale = 0.07637093,
   df = 8L
 )
 


### PR DESCRIPTION
Fixes #29.

The documented interface for `predict.emaxnls()` states that when `se.fit = TRUE` the return value contains `fit`, `se.fit`, `residual.scale`, and `df`. The `residual.scale` component was missing from both return paths (`interval = "none"` and `interval = "confidence"`) in `.predict_nls()`.

Added `residual.scale = summary(object)$sigma` (the estimated residual standard deviation from the NLS fit) to both paths, matching the `stats::predict.lm()` convention. Updated tests to expect the new component.