### PR TITLE
Fix initialisation crashes and Inf parameter bounds

### DIFF
--- a/R/emaxlogistic-init.R
+++ b/R/emaxlogistic-init.R
@@ -80,6 +80,14 @@
   n_total    <- length(exposure)
   n_dosed    <- n_total - n_placebo
 
+  if (n_dosed == 0L) {
+    stop(
+      "cannot initialise Emax parameters: data contains no dosed observations ",
+      "(all exposure values are 0)",
+      call. = FALSE
+    )
+  }
+
   log_exp_dosed  <- log(exposure[!is_placebo])
   rsp_logit_dosed <- response_logit[!is_placebo]
 

--- a/R/emaxnls-init.R
+++ b/R/emaxnls-init.R
@@ -82,6 +82,14 @@
   n_total <- length(exposure)
   n_dosed <- n_total - n_placebo
 
+  if (n_dosed == 0L) {
+    stop(
+      "cannot initialise Emax parameters: data contains no dosed observations ",
+      "(all exposure values are 0)",
+      call. = FALSE
+    )
+  }
+
   # log-exposure and response for the dosed samples
   log_exp_dosed <- log(exposure[!is_placebo])
   rsp_dosed <- response[!is_placebo]
@@ -136,15 +144,27 @@
 
 # guess the scale associated with key variables
 .guess_var_scale <- function(exposure, response, residuals, cov_names, design) {
+  cov_sds <- .map_dbl(
+    .x = cov_names,
+    .f = function(nn) stats::sd(design[[nn]])
+  )
+  names(cov_sds) <- cov_names
+  if (any(cov_sds == 0, na.rm = TRUE)) {
+    zero_names <- cov_names[!is.na(cov_sds) & cov_sds == 0]
+    rlang::warn(
+      paste0(
+        "covariate(s) with zero variance: ", paste(zero_names, collapse = ", "),
+        "; using sd = 1 for parameter bound estimation"
+      ),
+      class = "emaxnls_warning"
+    )
+    cov_sds[!is.na(cov_sds) & cov_sds == 0] <- 1
+  }
   sds <- list(
-    cov = .map_dbl(
-      .x = cov_names,
-      .f = function(nn) stats::sd(design[[nn]])
-    ),
+    cov = cov_sds,
     exp = stats::sd(exposure),
     rsp = stats::sd(response),
     res = stats::sd(residuals)
   )
-  names(sds$cov) <- cov_names
   return(sds)
 }


### PR DESCRIPTION
Fixes #30, #35.

## Changes

### All-placebo data crash (#30)
`.guess_base()` and `.guess_base_logistic()` split observations into placebo and dosed groups and then fit a log-linear model on the dosed subset. When all observations have `exposure == 0`, the dosed subset is empty and `lm()` crashes with an uninformative error. Added an early check:

```r
if (n_dosed == 0L) stop("cannot initialise Emax parameters: data contains no dosed observations (all exposure values are 0)")
```

### Zero-variance covariate produces Inf bounds (#35)
`.guess_var_scale()` computes `sd()` for each covariate. When a covariate is constant, `sd` returns `0`, causing division by zero and `Inf` lower/upper bounds. Now emits an `emaxnls_warning` identifying the zero-variance covariate(s) and substitutes `sd = 1` as a fallback.