### PR TITLE
Harden .nls_call() and .validate_emax_fun_args()

### DIFF
--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -254,6 +254,7 @@
     .validate_optim_method("levenberg")
     return(do.call(.nls_lm_safe, base_args))
   }
+  .abort(paste0("unknown algorithm: '", algorithm, "'"))
 }
 
 .nls_method <- function(optim_method) {

--- a/R/utils-validators.R
+++ b/R/utils-validators.R
@@ -90,10 +90,12 @@
     is.null(param) | (is.numeric(param) & length(param) == length(coef(mod))) , 
     "`param` must be a named numeric vector of parameters or NULL"
   )
-  .assert(
-    names(param) == names(coef(mod)), 
-    "`param` names must match those of the model coefficients"
-  )
+  if (!is.null(param)) {
+    .assert(
+      identical(names(param), names(coef(mod))),
+      "`param` names must match those of the model coefficients"
+    )
+  }
 }
 
 .validate_binary_response <- function(response, name) {


### PR DESCRIPTION
Fixes #31, #34.

## Changes

### Explicit error in .nls_call() for unknown algorithm (#31)
`.nls_call()` dispatched on the `algorithm` argument with three `if` branches and no `else`, silently returning `NULL` if none matched. Callers expect a list with `$result` and `$error`, so a `NULL` return would propagate to a confusing downstream failure. Added `.abort()` as a defensive final case.

### Names check guard in .validate_emax_fun_args() (#34)
The second assertion (`names(param) == names(coef(mod))`) ran unconditionally even when `param` is `NULL`. In that case `names(NULL) == names(coef(mod))` returns `logical(0)`, which happens to pass `.assert()` silently — but this is fragile. Wrapped the check in `if (!is.null(param))` and switched to `identical()` for clarity.