### PR TITLE
Add binary-response validation to emax_logistic()

### DIFF
--- a/R/emaxlogistic-class.R
+++ b/R/emaxlogistic-class.R
@@ -8,6 +8,9 @@
   .validate_structural_formula(structural_model, names(data))
   .validate_covariate_formula(covariate_model, names(data))
 
+  rsp_name <- as.character(structural_model[[2L]])
+  .validate_binary_response(data[[rsp_name]], rsp_name)
+
   names(covariate_model) <- .map_chr(covariate_model, function(x) as.character(x[[2]]))
 
   if (is.null(opts)) opts <- emax_logistic_options()

--- a/R/utils-validators.R
+++ b/R/utils-validators.R
@@ -96,6 +96,17 @@
   )
 }
 
+.validate_binary_response <- function(response, name) {
+  valid_vals <- all(response %in% c(0, 1, NA))
+  .assert(
+    valid_vals,
+    paste0(
+      "response variable '", name, "' must be binary (0/1); ",
+      "for continuous outcomes use emax_nls() instead"
+    )
+  )
+}
+
 .is_same <- function(mod1, mod2) {
   identical(
     .get_coefficient_names(mod1), 


### PR DESCRIPTION
Fixes #32.

`emax_logistic()` had no check that the response variable actually contains binary (0/1) values. Passing a continuous response is a common user error; the IRLS algorithm would run to completion and return plausible-looking but meaningless estimates with no warning.

Added `.validate_binary_response()` in `utils-validators.R` and called it from `.emax_logistic()` after the standard formula validations. When the response contains values outside `{0, 1, NA}` the error message names the offending variable and points the user to `emax_nls()`.