### PR TITLE
Fix .binomial_deviance() and deviance residuals at boundary probabilities

### DIFF
--- a/R/emaxlogistic-class.R
+++ b/R/emaxlogistic-class.R
@@ -141,5 +141,7 @@
 }
 
 .binomial_deviance <- function(y, mu) {
+  eps <- .Machine$double.eps
+  mu  <- pmin(pmax(mu, eps), 1 - eps)
   -2 * sum(y * log(mu) + (1 - y) * log(1 - mu))
 }

--- a/R/emaxlogistic-methods.R
+++ b/R/emaxlogistic-methods.R
@@ -38,7 +38,10 @@ residuals.emaxlogistic <- function(object, type = c("pearson", "deviance"), ...)
     return((y - mu) / sqrt(mu * (1 - mu)))
   }
   # deviance residuals: signed sqrt of per-observation deviance contribution
-  sign(y - mu) * sqrt(-2 * (y * log(mu) + (1 - y) * log(1 - mu)))
+  # clamp mu away from 0/1 to avoid log(0) = -Inf -> NaN
+  eps <- .Machine$double.eps
+  mu_clamped <- pmin(pmax(mu, eps), 1 - eps)
+  sign(y - mu) * sqrt(-2 * (y * log(mu_clamped) + (1 - y) * log(1 - mu_clamped)))
 }
 
 


### PR DESCRIPTION
Fixes #36.

When the NLS optimiser drives fitted probabilities to exactly 0 or 1 (which can happen with well-separated binary data), `log(0) = -Inf` and `.binomial_deviance()` returns `Inf` or `NaN`. This propagates through IRLS convergence checking, `deviance()`, `logLik()`, and `AIC()`.

The deviance residuals in `residuals.emaxlogistic()` had the same issue.

**Fix:** clamp `mu` to `[.Machine$double.eps, 1 - .Machine$double.eps]` before the log computations in both functions. This is the same approach used by base R's `stats::glm()` for computing binomial deviance.