### PR TITLE
Support simultaneous intervals in confint() (#46)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,12 @@
 * Fixes `NaN` produced by `.binomial_deviance()` when predicted probabilities
   are exactly 0 or 1 (boundary cases) (#44).
 
+* `confint()` now accepts a `simultaneous` argument, mirroring `summary()`.
+  Previously `confint(object, simultaneous = TRUE)` silently ignored the
+  argument (swallowed by `...`) and returned pointwise intervals. Setting
+  `simultaneous = TRUE` now returns simultaneous (joint) Wald intervals that
+  match those reported by `summary(object, simultaneous = TRUE)` (#46).
+
 
 # emaxnls 0.1.1
 

--- a/R/emaxnls-methods.R
+++ b/R/emaxnls-methods.R
@@ -646,14 +646,25 @@ fitted.emaxnls <- function(object, ...) {
 #'   are considered.
 #' @param level The confidence level required
 #' @param back_transform Should log-scaled parameters (logEC50, logHill) be back-transformed to original scale?
+#' @param simultaneous If `TRUE`, return simultaneous (joint) Wald confidence
+#'   intervals rather than the default profile likelihood intervals. Defaults
+#'   to `FALSE`.
 #' @param ... Ignored
 #'
 #' @details
-#' For `emaxnls` objects, this calls `stats::confint.nls()`. For
-#' `emaxlogistic` objects, the same profiling approach is applied to the
-#' final NLS fit from the IRLS algorithm at convergence. If profile likelihood
-#' computation fails (which can occur for sigmoidal models), a warning is
-#' issued and Wald intervals are returned instead.
+#' By default, and when `simultaneous = FALSE`, this calls
+#' `stats::confint.nls()` for `emaxnls` objects. For `emaxlogistic` objects,
+#' the same profiling approach is applied to the final NLS fit from the IRLS
+#' algorithm at convergence. If profile likelihood computation fails (which can
+#' occur for sigmoidal models), a warning is issued and Wald intervals are
+#' returned instead.
+#'
+#' When `simultaneous = TRUE`, a single critical value is derived from the
+#' joint multivariate normal distribution of the standardized parameter
+#' estimates (via [mvtnorm::qmvnorm()]). The resulting intervals have
+#' simultaneous coverage at `level` across all parameters and will be wider
+#' than the individual (pointwise) intervals. This matches the intervals
+#' produced by `summary(object, simultaneous = TRUE)`.
 #'
 #' Setting `back_transform = TRUE` exponentiates the confidence limits for
 #' logEC50 and logHill, expressing them on the concentration scale rather
@@ -680,6 +691,9 @@ fitted.emaxnls <- function(object, ...) {
 #' # 95% confidence interval with log-scale parameters back-transformed
 #' confint(mod_c, back_transform = TRUE)
 #'
+#' # simultaneous (joint) confidence intervals
+#' confint(mod_c, simultaneous = TRUE)
+#'
 #' mod_b <- emax_logistic(
 #'   structural_model = rsp_2 ~ exp_1,
 #'   covariate_model = list(E0 ~ cnt_a, Emax ~ 1, logEC50 ~ 1),
@@ -688,29 +702,35 @@ fitted.emaxnls <- function(object, ...) {
 #' confint(mod_b)
 #'
 #' @exportS3Method stats::confint
-confint.emaxnls <- function(object, parm = NULL, level = 0.95, back_transform = FALSE, ...) {
+confint.emaxnls <- function(object, parm = NULL, level = 0.95, back_transform = FALSE,
+                            simultaneous = FALSE, ...) {
   if (!.is_converged(object)) return(.nls_null())
 
   nls_obj <- .get_nls(object)
 
-  ci <- tryCatch(
-    {
-      if (is.null(parm)) {
-        .confint_quiet(nls_obj, level = level, ...)$result
-      } else {
-        .confint_quiet(nls_obj, parm = parm, level = level, ...)$result
+  if (simultaneous) {
+    ci <- .simultaneous_ci(object, level = level)
+    if (!is.null(parm)) ci <- ci[parm, , drop = FALSE]
+  } else {
+    ci <- tryCatch(
+      {
+        if (is.null(parm)) {
+          .confint_quiet(nls_obj, level = level, ...)$result
+        } else {
+          .confint_quiet(nls_obj, parm = parm, level = level, ...)$result
+        }
+      },
+      error = function(e) {
+        .warn(paste0(
+          "Profile likelihood confidence intervals failed; ",
+          "falling back to Wald intervals."
+        ))
+        df     <- if (.is_emaxlogistic(object)) NULL else stats::df.residual(nls_obj)
+        all_ci <- .wald_ci(nls_obj, level = level, df = df)
+        if (is.null(parm)) all_ci else all_ci[parm, , drop = FALSE]
       }
-    },
-    error = function(e) {
-      .warn(paste0(
-        "Profile likelihood confidence intervals failed; ",
-        "falling back to Wald intervals."
-      ))
-      df     <- if (.is_emaxlogistic(object)) NULL else stats::df.residual(nls_obj)
-      all_ci <- .wald_ci(nls_obj, level = level, df = df)
-      if (is.null(parm)) all_ci else all_ci[parm, , drop = FALSE]
-    }
-  )
+    )
+  }
 
   if (back_transform) {
     trans_cases <- grep("^log", rownames(ci))

--- a/man/confint.emaxnls.Rd
+++ b/man/confint.emaxnls.Rd
@@ -4,7 +4,14 @@
 \alias{confint.emaxnls}
 \title{Confidence intervals for Emax regression model parameters}
 \usage{
-\method{confint}{emaxnls}(object, parm = NULL, level = 0.95, back_transform = FALSE, ...)
+\method{confint}{emaxnls}(
+  object,
+  parm = NULL,
+  level = 0.95,
+  back_transform = FALSE,
+  simultaneous = FALSE,
+  ...
+)
 }
 \arguments{
 \item{object}{An \code{emaxnls} or \code{emaxlogistic} object}
@@ -16,6 +23,10 @@ are considered.}
 \item{level}{The confidence level required}
 
 \item{back_transform}{Should log-scaled parameters (logEC50, logHill) be back-transformed to original scale?}
+
+\item{simultaneous}{If \code{TRUE}, return simultaneous (joint) Wald confidence
+intervals rather than the default profile likelihood intervals. Defaults
+to \code{FALSE}.}
 
 \item{...}{Ignored}
 }
@@ -31,11 +42,19 @@ nonlinear settings because they do not assume the likelihood surface is
 quadratic near the estimates.
 }
 \details{
-For \code{emaxnls} objects, this calls \code{stats::confint.nls()}. For
-\code{emaxlogistic} objects, the same profiling approach is applied to the
-final NLS fit from the IRLS algorithm at convergence. If profile likelihood
-computation fails (which can occur for sigmoidal models), a warning is
-issued and Wald intervals are returned instead.
+By default, and when \code{simultaneous = FALSE}, this calls
+\code{stats::confint.nls()} for \code{emaxnls} objects. For \code{emaxlogistic} objects,
+the same profiling approach is applied to the final NLS fit from the IRLS
+algorithm at convergence. If profile likelihood computation fails (which can
+occur for sigmoidal models), a warning is issued and Wald intervals are
+returned instead.
+
+When \code{simultaneous = TRUE}, a single critical value is derived from the
+joint multivariate normal distribution of the standardized parameter
+estimates (via \code{\link[mvtnorm:qmvnorm]{mvtnorm::qmvnorm()}}). The resulting intervals have
+simultaneous coverage at \code{level} across all parameters and will be wider
+than the individual (pointwise) intervals. This matches the intervals
+produced by \code{summary(object, simultaneous = TRUE)}.
 
 Setting \code{back_transform = TRUE} exponentiates the confidence limits for
 logEC50 and logHill, expressing them on the concentration scale rather
@@ -57,6 +76,9 @@ confint(mod_c, level = 0.9)
 
 # 95\% confidence interval with log-scale parameters back-transformed
 confint(mod_c, back_transform = TRUE)
+
+# simultaneous (joint) confidence intervals
+confint(mod_c, simultaneous = TRUE)
 
 mod_b <- emax_logistic(
   structural_model = rsp_2 ~ exp_1,

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -130,6 +130,43 @@ test_that("back_transform works for coef()", {
   expect_equal(unname(cc1[4]), unname(log(cc2[4])))
 }) 
 
+test_that("confint(simultaneous = TRUE) matches summary(simultaneous = TRUE)", {
+  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_installed("mvtnorm")
+  # qmvnorm() uses randomised quasi-Monte Carlo, so the critical value varies
+  # slightly between calls; compare with a tolerance rather than exactly.
+  ci <- confint(mod, simultaneous = TRUE)
+  s  <- summary(mod, simultaneous = TRUE)
+  expect_equal(unname(ci[, 1]), unname(s$ci_lower), tolerance = 1e-2)
+  expect_equal(unname(ci[, 2]), unname(s$ci_upper), tolerance = 1e-2)
+})
+
+test_that("confint(simultaneous = TRUE) gives wider intervals than pointwise", {
+  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_installed("mvtnorm")
+  ci_sim <- confint(mod, simultaneous = TRUE)
+  est    <- stats::coef(mod)
+  se     <- sqrt(diag(stats::vcov(mod)))
+  t_crit <- stats::qt(0.975, df = stats::df.residual(mod))
+  expect_true(all(ci_sim[, 1] <= est - t_crit * se))
+  expect_true(all(ci_sim[, 2] >= est + t_crit * se))
+})
+
+test_that("confint(simultaneous = TRUE) respects parm and back_transform", {
+  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_installed("mvtnorm")
+  full <- confint(mod, simultaneous = TRUE)
+  parm <- rownames(full)[1:2]
+  sub  <- confint(mod, parm = parm, simultaneous = TRUE)
+  expect_equal(nrow(sub), 2L)
+  expect_equal(rownames(sub), parm)
+
+  bt <- confint(mod, simultaneous = TRUE, back_transform = TRUE)
+  # log-scale rows are exponentiated; row name loses its "log" prefix
+  expect_true(any(grepl("^EC50", rownames(bt))))
+  expect_false(any(grepl("^logEC50", rownames(bt))))
+})
+
 test_that("confint() falls back to Wald intervals with a warning for sigmoidal models", {
   mod_sig <- emax_nls(
     structural_model = rsp_1 ~ exp_1,


### PR DESCRIPTION
confint() previously accepted `simultaneous` only through `...`, where it was silently ignored and pointwise profile-likelihood intervals were returned regardless. Add an explicit `simultaneous` argument to confint.emaxnls() that dispatches to the same .simultaneous_ci() helper used by summary(), so confint(object, simultaneous = TRUE) now returns simultaneous (joint) Wald intervals matching summary(). The argument honours `parm` subsetting and `back_transform`.

closes #46 