### PR TITLE
Clarify relationship between p_adjust and simultaneous in summary() (#47)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,17 @@
 * `confint()` now falls back to Wald intervals with a warning if profile
   likelihood computation fails (which can occur for sigmoidal models).
 
+## Documentation
+
+* Expands the `summary()` documentation to explain the relationship between
+  the `p_adjust` and `simultaneous` arguments. The two are independent tools
+  for multiplicity — `p_adjust` corrects the hypothesis-test p-values, while
+  `simultaneous` widens the confidence intervals — and they use different
+  machinery, so their reject/retain decisions need not agree. The new
+  "Multiplicity: p-value adjustment versus simultaneous intervals" section
+  spells out what each argument changes, why the adjusted p-values and the
+  simultaneous intervals may disagree, and which tool to reach for (#47).
+
 ## Bug fixes
 
 * Fixes `AIC()` and `BIC()` when called with multiple model arguments (#37).

--- a/R/emaxnls-printing.R
+++ b/R/emaxnls-printing.R
@@ -88,12 +88,16 @@ print.emaxnls <- function(x, conf_level = 0.95, ...) {
 #' @param p_adjust Method for adjusting p-values for multiple comparisons,
 #'   passed to [stats::p.adjust()]. Defaults to `"none"`. Parameters with
 #'   suppressed p-values (see `suppress_nonsensical`) are excluded from the
-#'   adjustment set.
+#'   adjustment set. This affects only the `p_value` column and is independent
+#'   of `simultaneous`; see the "Multiplicity: p-value adjustment versus
+#'   simultaneous intervals" section below.
 #' @param simultaneous If `TRUE`, compute simultaneous (joint) confidence
 #'   intervals using the multivariate normal distribution via
 #'   [mvtnorm::qmvnorm()]. This gives wider intervals that provide joint
 #'   coverage at `conf_level` across all parameters simultaneously. Defaults
-#'   to `FALSE`.
+#'   to `FALSE`. This affects only the confidence-interval columns and is
+#'   independent of `p_adjust`; see the "Multiplicity: p-value adjustment
+#'   versus simultaneous intervals" section below.
 #' @param suppress_nonsensical If `TRUE` (the default), suppress the test
 #'   statistic and p-value for `logEC50_Intercept`. The logEC50 intercept is
 #'   estimated on the log-concentration scale, and testing `H0: logEC50 = 0`
@@ -131,8 +135,70 @@ print.emaxnls <- function(x, conf_level = 0.95, ...) {
 #'
 #' When `simultaneous = TRUE`, a single critical value is derived from the
 #' joint multivariate normal distribution of the standardized parameter
-#' estimates. The resulting intervals have simultaneous coverage at 
+#' estimates. The resulting intervals have simultaneous coverage at
 #' `conf_level` and will be wider than the individual (pointwise) intervals.
+#'
+#' ## Multiplicity: p-value adjustment versus simultaneous intervals
+#'
+#' A model with several parameters raises a multiple-comparisons problem: the
+#' more quantities you inspect, the more likely at least one spurious result
+#' appears by chance. `summary()` offers two, deliberately separate, tools for
+#' this, and it is worth being clear about how they differ because they are
+#' easy to conflate.
+#'
+#' - `p_adjust` acts on the **hypothesis tests**. It takes the marginal
+#'   (per-parameter) p-values and feeds them through [stats::p.adjust()],
+#'   which applies a sequential rule such as Holm or a Bonferroni scaling.
+#'   These rules look only at the *set of p-values*; they do not use the
+#'   estimated correlations between the parameters. Only the `p_value` column
+#'   changes. The estimates, standard errors, test statistics, and confidence
+#'   intervals are untouched.
+#' - `simultaneous` acts on the **interval estimates**. It replaces the
+#'   per-parameter critical value with a single, larger critical value taken
+#'   from the joint multivariate normal distribution of the estimates (via
+#'   [mvtnorm::qmvnorm()]), which *does* use the correlation structure from
+#'   `vcov()`. Only the `ci_lower` and `ci_upper` columns change. The
+#'   p-values and test statistics are untouched.
+#'
+#' The two arguments are fully independent: you may set either, both, or
+#' neither, and each does exactly the one thing described above. Neither
+#' argument modifies the other's output.
+#'
+#' ### Why the adjusted p-values and the intervals may disagree
+#'
+#' Because the two corrections use different machinery, they will not, in
+#' general, agree on which parameters are "significant". A parameter can have
+#' a Holm-adjusted p-value below `1 - conf_level` while its simultaneous
+#' confidence interval still contains zero, or the reverse. This is not a bug.
+#' The familiar duality — "the 95% interval excludes zero if and only if the
+#' two-sided test rejects at the 5% level" — holds only for a *single*,
+#' unadjusted Wald comparison. It breaks as soon as a multiplicity correction
+#' enters, for two reasons:
+#'
+#' - the corrections answer different questions (a step-down rule on the
+#'   p-values versus a joint critical region for the intervals), and
+#' - they use different information (`p.adjust()` ignores the parameter
+#'   correlations that the simultaneous interval is built from).
+#'
+#' A further, smaller source of discrepancy: unless the profile-likelihood
+#' computation falls back to Wald intervals, the default (pointwise) intervals
+#' are profile-likelihood based, whereas the reported test statistics and
+#' p-values are Wald quantities, so even *without* any adjustment the two need
+#' not correspond exactly in nonlinear models.
+#'
+#' ### Which one to use
+#'
+#' Pick the tool that matches the claim you want to make, and interpret its
+#' output on its own terms rather than cross-checking one against the other:
+#'
+#' - To report **interval estimates** that are jointly valid across all
+#'   parameters, use `simultaneous = TRUE`.
+#' - To control the family-wise (or false-discovery) error rate of a set of
+#'   **hypothesis tests**, choose a `p_adjust` method.
+#'
+#' Setting both is legitimate, but the adjusted p-values and the simultaneous
+#' intervals are then two separate summaries of multiplicity, not two views of
+#' the same one, and should be read as such.
 #'
 #' @returns A tibble with one row per model parameter and columns for the
 #'   estimate, standard error, test statistic, p-value, and confidence

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,7 +1,9 @@
+Bonferroni
 CMD
 Codecov
 Emax
 Golub
+Holm
 IRLS
 Levenberg
 Lifecycle

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -41,13 +41,17 @@ are set to \code{NA}.}
 \item{p_adjust}{Method for adjusting p-values for multiple comparisons,
 passed to \code{\link[stats:p.adjust]{stats::p.adjust()}}. Defaults to \code{"none"}. Parameters with
 suppressed p-values (see \code{suppress_nonsensical}) are excluded from the
-adjustment set.}
+adjustment set. This affects only the \code{p_value} column and is independent
+of \code{simultaneous}; see the "Multiplicity: p-value adjustment versus
+simultaneous intervals" section below.}
 
 \item{simultaneous}{If \code{TRUE}, compute simultaneous (joint) confidence
 intervals using the multivariate normal distribution via
 \code{\link[mvtnorm:qmvnorm]{mvtnorm::qmvnorm()}}. This gives wider intervals that provide joint
 coverage at \code{conf_level} across all parameters simultaneously. Defaults
-to \code{FALSE}.}
+to \code{FALSE}. This affects only the confidence-interval columns and is
+independent of \code{p_adjust}; see the "Multiplicity: p-value adjustment
+versus simultaneous intervals" section below.}
 
 \item{suppress_nonsensical}{If \code{TRUE} (the default), suppress the test
 statistic and p-value for \code{logEC50_Intercept}. The logEC50 intercept is
@@ -105,6 +109,74 @@ When \code{simultaneous = TRUE}, a single critical value is derived from the
 joint multivariate normal distribution of the standardized parameter
 estimates. The resulting intervals have simultaneous coverage at
 \code{conf_level} and will be wider than the individual (pointwise) intervals.
+}
+
+\subsection{Multiplicity: p-value adjustment versus simultaneous intervals}{
+
+A model with several parameters raises a multiple-comparisons problem: the
+more quantities you inspect, the more likely at least one spurious result
+appears by chance. \code{summary()} offers two, deliberately separate, tools for
+this, and it is worth being clear about how they differ because they are
+easy to conflate.
+\itemize{
+\item \code{p_adjust} acts on the \strong{hypothesis tests}. It takes the marginal
+(per-parameter) p-values and feeds them through \code{\link[stats:p.adjust]{stats::p.adjust()}},
+which applies a sequential rule such as Holm or a Bonferroni scaling.
+These rules look only at the \emph{set of p-values}; they do not use the
+estimated correlations between the parameters. Only the \code{p_value} column
+changes. The estimates, standard errors, test statistics, and confidence
+intervals are untouched.
+\item \code{simultaneous} acts on the \strong{interval estimates}. It replaces the
+per-parameter critical value with a single, larger critical value taken
+from the joint multivariate normal distribution of the estimates (via
+\code{\link[mvtnorm:qmvnorm]{mvtnorm::qmvnorm()}}), which \emph{does} use the correlation structure from
+\code{vcov()}. Only the \code{ci_lower} and \code{ci_upper} columns change. The
+p-values and test statistics are untouched.
+}
+
+The two arguments are fully independent: you may set either, both, or
+neither, and each does exactly the one thing described above. Neither
+argument modifies the other's output.
+\subsection{Why the adjusted p-values and the intervals may disagree}{
+
+Because the two corrections use different machinery, they will not, in
+general, agree on which parameters are "significant". A parameter can have
+a Holm-adjusted p-value below \code{1 - conf_level} while its simultaneous
+confidence interval still contains zero, or the reverse. This is not a bug.
+The familiar duality — "the 95\% interval excludes zero if and only if the
+two-sided test rejects at the 5\% level" — holds only for a \emph{single},
+unadjusted Wald comparison. It breaks as soon as a multiplicity correction
+enters, for two reasons:
+\itemize{
+\item the corrections answer different questions (a step-down rule on the
+p-values versus a joint critical region for the intervals), and
+\item they use different information (\code{p.adjust()} ignores the parameter
+correlations that the simultaneous interval is built from).
+}
+
+A further, smaller source of discrepancy: unless the profile-likelihood
+computation falls back to Wald intervals, the default (pointwise) intervals
+are profile-likelihood based, whereas the reported test statistics and
+p-values are Wald quantities, so even \emph{without} any adjustment the two need
+not correspond exactly in nonlinear models.
+}
+
+\subsection{Which one to use}{
+
+Pick the tool that matches the claim you want to make, and interpret its
+output on its own terms rather than cross-checking one against the other:
+\itemize{
+\item To report \strong{interval estimates} that are jointly valid across all
+parameters, use \code{simultaneous = TRUE}.
+\item To control the family-wise (or false-discovery) error rate of a set of
+\strong{hypothesis tests}, choose a \code{p_adjust} method.
+}
+
+Setting both is legitimate, but the adjusted p-values and the simultaneous
+intervals are then two separate summaries of multiplicity, not two views of
+the same one, and should be read as such.
+}
+
 }
 }
 \examples{


### PR DESCRIPTION
## Summary

Addresses #47. The `summary()` documentation did not explain how the `p_adjust` and `simultaneous` arguments relate, and users without a strong stats background may expect them to work together as a single multiplicity adjustment.

They are in fact **independent** tools acting on different columns of the coefficient table:

- `p_adjust` corrects the **hypothesis-test p-values** (via `stats::p.adjust()`, using only the marginal p-values).
- `simultaneous` widens the **confidence intervals** (via `mvtnorm::qmvnorm()`, using the parameter correlation structure from `vcov()`).

Because they use different machinery, their reject/retain decisions need not agree â€” the usual CI/test duality holds only for a single unadjusted Wald comparison.

## Changes

- Adds a **"Multiplicity: p-value adjustment versus simultaneous intervals"** section to the `summary()` roxygen docs, explaining what each argument changes, why adjusted p-values and simultaneous intervals may disagree (including the Wald vs profile-likelihood mismatch), and which tool to reach for.
- Cross-references the new section from both the `p_adjust` and `simultaneous` `@param` entries.
- Regenerates `man/summary.Rd`.
- Adds `Bonferroni` and `Holm` to `inst/WORDLIST`.
- Adds a NEWS.md entry under a new Documentation heading.

Documentation-only change; no code behaviour is altered.
