### PR TITLE
Move tibble from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,11 +20,11 @@ Imports:
     mvtnorm,
     rlang,
     stats,
-    tibble,
     utils
 Suggests: 
     spelling,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    tibble
 Config/Needs/website: djnavarro/waeponwifestre, rmarkdown, ggplot2
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # emaxnls 0.1.1.9000
 
+## Bug fixes
+
+* The tibble package is now listed under `Suggests` rather than `Imports`, making it a genuine optional dependency. All package functionality works with or without tibble installed (#24).
+
 ## New features
 
 * Adds `emax_logistic()` for fitting binary-outcome Emax models using iterative


### PR DESCRIPTION
Closes #24.

tibble was listed as an `Imports` dependency despite the package already being designed to work without it. The wrapper functions in `R/utils-tibble.R` already use `rlang::is_installed("tibble")` to gracefully fall back to base-R equivalents, so no logic changes were needed — only the `DESCRIPTION` field needed correcting.

## Changes

- **`DESCRIPTION`**: moved `tibble` from `Imports` to `Suggests`
- **`NEWS.md`**: added bug-fix entry

## Testing

All 632 tests pass with tibble available (the existing `tests/testthat/test-utils-tibble.R` already covers both code paths: once with tibble installed and once simulating its absence via `.no_tibble = TRUE`).