### PR TITLE
fix: standardise skip behaviour across test suite

### DIFF
--- a/tests/testthat/helper-platform.R
+++ b/tests/testthat/helper-platform.R
@@ -49,6 +49,14 @@ is_gcc_version <- function(major) {
 is_gcc15 <- function() is_gcc_version(15)
 
 
+# skip a test that assumes model convergence if the model did not converge;
+# used throughout the test suite to guard tests that use a fitted model but
+# are not themselves testing convergence
+skip_if_not_converged <- function(mod) {
+  skip_if(!.is_converged(mod), "Skip: model did not converge on this architecture")
+}
+
+
 # check whether mvtnorm is actually callable, not just installed -------------
 #
 # On some clang-based Rhub builders, mvtnorm is installed and its namespace can

--- a/tests/testthat/test-emaxlogistic-class.R
+++ b/tests/testthat/test-emaxlogistic-class.R
@@ -19,7 +19,7 @@ test_that("emax_logistic() returns an emaxlogistic object", {
 })
 
 test_that("emax_logistic() object has correct structure", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   expect_named(mod, c("formula", "data", "info", "env"))
   expect_named(mod$formula, c("structural", "covariate", "expanded"))
   expect_named(mod$info, c("opts", "init", "design", "model_type", "variables"))
@@ -28,14 +28,14 @@ test_that("emax_logistic() object has correct structure", {
 })
 
 test_that("emax_converged() works for emaxlogistic objects", {
-  if (!.is_converged(mod)) skip() # not ideal in this case
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod)
+  skip_if_not_converged(mod_cov)
   expect_true(emax_converged(mod))
   expect_true(emax_converged(mod_cov))
 })
 
 test_that("IRLS diagnostics are stored correctly", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   irls <- .get_irls(mod)
   expect_true(irls$converged)
   expect_true(irls$iter >= 1L)
@@ -84,7 +84,7 @@ test_that("sigmoidal logistic Emax model fits successfully", {
     covariate_model  = list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1, logHill ~ 1),
     data             = emax_df
   )
-  if (!.is_converged(mod_sig)) skip() # again, not ideal here
+  skip_if_not_converged(mod_sig)
   expect_true(emax_converged(mod_sig))
   expect_equal(.get_model_type(mod_sig), "sigmoidal")
   expect_length(coef(mod_sig), 4L)

--- a/tests/testthat/test-emaxlogistic-methods.R
+++ b/tests/testthat/test-emaxlogistic-methods.R
@@ -17,7 +17,7 @@ mod_cov <- emax_logistic(
 # coef() ------------------------------------------------------------------
 
 test_that("coef() returns named numeric vector", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   cc <- coef(mod_base)
   expect_true(is.numeric(cc))
   expect_named(cc)
@@ -25,7 +25,7 @@ test_that("coef() returns named numeric vector", {
 })
 
 test_that("coef(back_transform = TRUE) transforms log-scale parameters", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   cc_raw   <- coef(mod_base)
   cc_trans <- coef(mod_base, back_transform = TRUE)
   expect_equal(cc_trans["EC50_Intercept"], exp(cc_raw["logEC50_Intercept"]),
@@ -36,7 +36,7 @@ test_that("coef(back_transform = TRUE) transforms log-scale parameters", {
 # fitted() ----------------------------------------------------------------
 
 test_that("fitted() returns probabilities by default", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   f <- fitted(mod_base)
   expect_true(is.numeric(f))
   expect_length(f, nrow(emax_df))
@@ -44,7 +44,7 @@ test_that("fitted() returns probabilities by default", {
 })
 
 test_that("fitted(type = 'link') returns logit-scale predictions", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   f_link <- fitted(mod_base, type = "link")
   f_resp <- fitted(mod_base, type = "response")
   expect_equal(f_link, .logit(f_resp))
@@ -54,14 +54,14 @@ test_that("fitted(type = 'link') returns logit-scale predictions", {
 # residuals() -------------------------------------------------------------
 
 test_that("residuals() returns Pearson residuals by default", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   r <- residuals(mod_base)
   expect_true(is.numeric(r))
   expect_length(r, nrow(emax_df))
 })
 
 test_that("residuals(type = 'deviance') returns deviance residuals", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   r_dev  <- residuals(mod_base, type = "deviance")
   r_pear <- residuals(mod_base, type = "pearson")
   # deviance and Pearson residuals should differ
@@ -69,7 +69,7 @@ test_that("residuals(type = 'deviance') returns deviance residuals", {
 })
 
 test_that("deviance residuals have correct sign", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   y <- emax_df$rsp_2
   r <- residuals(mod_base, type = "deviance")
   # positive residuals where y=1, negative where y=0 (unless perfectly predicted)
@@ -83,20 +83,20 @@ test_that("deviance residuals have correct sign", {
 # logLik() ----------------------------------------------------------------
 
 test_that("logLik() returns a logLik object", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   ll <- logLik(mod_base)
   expect_s3_class(ll, "logLik")
   expect_true(is.finite(as.numeric(ll)))
 })
 
 test_that("logLik() has correct df attribute", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   ll <- logLik(mod_base)
   expect_equal(attr(ll, "df"), length(coef(mod_base)))
 })
 
 test_that("logLik() equals hand-computed binomial log-likelihood", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   y  <- emax_df$rsp_2
   mu <- fitted(mod_base)
   expected <- sum(y * log(mu) + (1 - y) * log(1 - mu))
@@ -107,7 +107,7 @@ test_that("logLik() equals hand-computed binomial log-likelihood", {
 # deviance() --------------------------------------------------------------
 
 test_that("deviance() equals -2 * logLik()", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_equal(deviance(mod_base), -2 * as.numeric(logLik(mod_base)), tolerance = 1e-8)
 })
 
@@ -115,19 +115,19 @@ test_that("deviance() equals -2 * logLik()", {
 # AIC() and BIC() ---------------------------------------------------------
 
 test_that("AIC() returns a numeric scalar", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_true(is.numeric(AIC(mod_base)))
   expect_length(AIC(mod_base), 1L)
 })
 
 test_that("BIC() returns a numeric scalar", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_true(is.numeric(BIC(mod_base)))
   expect_length(BIC(mod_base), 1L)
 })
 
 test_that("AIC() equals -2*logLik + 2*npar", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   ll   <- logLik(mod_base)
   npar <- attr(ll, "df")
   expected <- -2 * as.numeric(ll) + 2 * npar
@@ -135,14 +135,14 @@ test_that("AIC() equals -2*logLik + 2*npar", {
 })
 
 test_that("model with covariate has lower AIC than base model", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   expect_lt(AIC(mod_cov), AIC(mod_base))
 })
 
 test_that("AIC(mod1, mod2) returns a data frame", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   out <- AIC(mod_base, mod_cov)
   expect_s3_class(out, "data.frame")
   expect_named(out, c("df", "AIC"))
@@ -150,8 +150,8 @@ test_that("AIC(mod1, mod2) returns a data frame", {
 })
 
 test_that("BIC(mod1, mod2) returns a data frame", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   out <- BIC(mod_base, mod_cov)
   expect_s3_class(out, "data.frame")
   expect_named(out, c("df", "BIC"))
@@ -161,12 +161,12 @@ test_that("BIC(mod1, mod2) returns a data frame", {
 # nobs() and df.residual() ------------------------------------------------
 
 test_that("nobs() returns the number of observations", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_equal(nobs(mod_base), nrow(emax_df))
 })
 
 test_that("df.residual() is nobs - npar", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   n    <- nobs(mod_base)
   npar <- length(coef(mod_base))
   expect_equal(df.residual(mod_base), n - npar)
@@ -176,8 +176,8 @@ test_that("df.residual() is nobs - npar", {
 # anova() -----------------------------------------------------------------
 
 test_that("anova() performs LRT and returns correct structure", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   a <- anova(mod_base, mod_cov)
   expect_s3_class(a, "data.frame")
   expect_true("Pr(>Chi)" %in% names(a))
@@ -186,15 +186,15 @@ test_that("anova() performs LRT and returns correct structure", {
 })
 
 test_that("anova() LRT p-value is significant when covariate improves fit", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   a <- anova(mod_base, mod_cov)
   expect_lt(a$`Pr(>Chi)`[2], 0.05)
 })
 
 test_that("anova() LRT statistic equals deviance difference", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   a <- anova(mod_base, mod_cov)
   expected_lrt <- deviance(mod_base) - deviance(mod_cov)
   expect_equal(a$LRT[2], expected_lrt, tolerance = 1e-8)
@@ -204,7 +204,7 @@ test_that("anova() LRT statistic equals deviance difference", {
 # predict() ---------------------------------------------------------------
 
 test_that("predict() returns probabilities by default", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   p <- predict(mod_base)
   expect_true(is.numeric(p))
   expect_true(all(p > 0 & p < 1))
@@ -212,19 +212,19 @@ test_that("predict() returns probabilities by default", {
 })
 
 test_that("predict() and fitted() agree on training data", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_equal(predict(mod_base), fitted(mod_base), tolerance = 1e-8, ignore_attr = TRUE)
 })
 
 test_that("predict(type = 'link') returns logit-scale predictions", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   p_link <- predict(mod_base, type = "link")
   p_resp <- predict(mod_base, type = "response")
   expect_equal(p_link, .logit(p_resp), tolerance = 1e-8)
 })
 
 test_that("predict() works with newdata", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   new_dat <- emax_df[1:10, ]
   p <- predict(mod_base, newdata = new_dat)
   expect_length(p, 10L)
@@ -235,21 +235,21 @@ test_that("predict() works with newdata", {
 # vcov() and confint() ----------------------------------------------------
 
 test_that("vcov() returns a square matrix", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   v <- vcov(mod_base)
   n <- length(coef(mod_base))
   expect_equal(dim(v), c(n, n))
 })
 
 test_that("confint() returns a matrix with correct dimensions", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   ci <- confint(mod_base)
   expect_equal(nrow(ci), length(coef(mod_base)))
   expect_equal(ncol(ci), 2L)
 })
 
 test_that("confint(back_transform = TRUE) transforms logEC50 to EC50 scale", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   ci_raw   <- confint(mod_base)
   ci_trans <- confint(mod_base, back_transform = TRUE)
   expect_equal(ci_trans["EC50_Intercept", ], exp(ci_raw["logEC50_Intercept", ]),
@@ -275,7 +275,7 @@ test_that("methods return null-like values for non-converged models", {
 # emax_add_term / emax_remove_term ----------------------------------------
 
 test_that("emax_add_term() preserves emaxlogistic class", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   mod_updated <- emax_add_term(mod_base, E0 ~ cnt_a)
   expect_s3_class(mod_updated, "emaxlogistic")
   expect_s3_class(mod_updated, "emaxnls")
@@ -283,7 +283,7 @@ test_that("emax_add_term() preserves emaxlogistic class", {
 })
 
 test_that("emax_remove_term() preserves emaxlogistic class", {
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_cov)
   mod_updated <- emax_remove_term(mod_cov, E0 ~ cnt_a)
   expect_s3_class(mod_updated, "emaxlogistic")
   expect_s3_class(mod_updated, "emaxnls")
@@ -291,7 +291,7 @@ test_that("emax_remove_term() preserves emaxlogistic class", {
 })
 
 test_that("emax_add_term() updates the covariate model and parameter count", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   mod_added <- emax_add_term(mod_base, E0 ~ cnt_a)
   expect_true("E0_cnt_a" %in% names(coef(mod_added)))
   expect_equal(length(coef(mod_added)), length(coef(mod_base)) + 1L)
@@ -299,7 +299,7 @@ test_that("emax_add_term() updates the covariate model and parameter count", {
 })
 
 test_that("emax_remove_term() updates the covariate model and parameter count", {
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_cov)
   mod_removed <- emax_remove_term(mod_cov, E0 ~ cnt_a)
   expect_false("E0_cnt_a" %in% names(coef(mod_removed)))
   expect_equal(length(coef(mod_removed)), length(coef(mod_cov)) - 1L)
@@ -307,7 +307,7 @@ test_that("emax_remove_term() updates the covariate model and parameter count", 
 })
 
 test_that("adding and then removing a term leaves the model structure unchanged", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   mod_add <- emax_add_term(mod_base, E0 ~ bin_d)
   mod_del <- emax_remove_term(mod_add, E0 ~ bin_d)
   expect_equal(names(coef(mod_del)), names(coef(mod_base)))
@@ -319,12 +319,12 @@ test_that("adding and then removing a term leaves the model structure unchanged"
 })
 
 test_that("emax_add_term() messages when term already exists", {
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_cov)
   expect_message(emax_add_term(mod_cov, E0 ~ cnt_a), class = "emaxnls_message")
 })
 
 test_that("emax_remove_term() messages when term is not present", { 
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_message(emax_remove_term(mod_base, E0 ~ cnt_a), class = "emaxnls_message")
 })
 
@@ -332,8 +332,8 @@ test_that("emax_remove_term() messages when term is not present", {
 # smoke test --------------------------------------------------------------
 
 test_that("methods do not throw errors with basic use", {
-  if (!.is_converged(mod_cov)) skip()
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_cov)
+  skip_if_not_converged(mod_base)
   expect_no_error(coef(mod_cov))
   expect_no_error(vcov(mod_cov))
   expect_no_error(residuals(mod_cov))
@@ -352,16 +352,16 @@ test_that("methods do not throw errors with basic use", {
 })
 
 test_that("AIC(), BIC(), and anova() can take multiple objects", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   expect_no_error(AIC(mod_base, mod_cov))
   expect_no_error(BIC(mod_base, mod_cov))
   expect_no_error(anova(mod_base, mod_cov))
 })
 
 test_that("AIC(), BIC(), and anova() handle cases where some models do not converge", {
-  if (!.is_converged(mod_base)) skip()
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_base)
+  skip_if_not_converged(mod_cov)
   expect_warning(AIC(mod_base, mod_cov, mod_bad))
   expect_warning(BIC(mod_base, mod_cov, mod_bad))
   expect_warning(anova(mod_base, mod_cov, mod_bad))
@@ -375,7 +375,7 @@ test_that("AIC(), BIC(), and anova() handle cases where some models do not conve
 # summary() ---------------------------------------------------------------
 
 test_that("summary() matches .coef_table_logistic()", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   expect_equal(summary(mod_base), .coef_table_logistic(mod_base, suppress_nonsensical = TRUE))
   expect_equal(summary(mod_base, conf_level = .99), .coef_table_logistic(mod_base, level = .99, suppress_nonsensical = TRUE))
   expect_equal(
@@ -388,7 +388,7 @@ test_that("summary() matches .coef_table_logistic()", {
 # vcov() ------------------------------------------------------------------
 
 test_that("vcov() is symmetric and has correct dimension names", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   v   <- vcov(mod_base)
   lbl <- names(coef(mod_base))
   expect_equal(rownames(v), lbl)
@@ -400,14 +400,14 @@ test_that("vcov() is symmetric and has correct dimension names", {
 # simulate() --------------------------------------------------------------
 
 test_that("simulate() returns a data frame with one row per observation", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   sim <- simulate(mod_base)
   expect_s3_class(sim, "data.frame")
   expect_equal(nrow(sim), nrow(emax_df))  # nsim = 1: long format gives n * 1 rows
 })
 
 test_that("simulate() respects the nsim argument", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   sim <- simulate(mod_base, nsim = 5L)
   # long format: one row per observation per simulation replicate
   expect_equal(nrow(sim), 5L * nrow(emax_df))
@@ -415,7 +415,7 @@ test_that("simulate() respects the nsim argument", {
 })
 
 test_that("simulate() produces binary values in the val column", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   sim <- simulate(mod_base)
   expect_true(all(sim$val %in% c(0, 1)))
 })
@@ -424,7 +424,7 @@ test_that("simulate() produces binary values in the val column", {
 # predict() with se.fit and interval --------------------------------------
 
 test_that("predict(se.fit = TRUE) returns a list with fit, se.fit, residual.scale, and df", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   pr <- predict(mod_base, se.fit = TRUE)
   expect_type(pr, "list")
   expect_named(pr, c("fit", "se.fit", "residual.scale", "df"))
@@ -435,7 +435,7 @@ test_that("predict(se.fit = TRUE) returns a list with fit, se.fit, residual.scal
 })
 
 test_that("predict(interval = 'confidence') returns a data frame of probabilities", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   pr <- predict(mod_base, interval = "confidence")
   expect_s3_class(pr, "data.frame")
   expect_named(pr, c("fit", "lwr", "upr"))
@@ -450,14 +450,14 @@ test_that("predict(interval = 'confidence') returns a data frame of probabilitie
 })
 
 test_that("predict(se.fit = TRUE) fit matches predict() on response scale", {
-  if (!.is_converged(mod_base)) skip()
+  skip_if_not_converged(mod_base)
   pr_vec <- predict(mod_base)
   pr_lst <- predict(mod_base, se.fit = TRUE)
   expect_equal(pr_lst$fit, pr_vec, tolerance = 1e-8, ignore_attr = TRUE)
 })
 
 test_that("predict with tibble newdata gives identical results to data.frame", {
-  if (!.is_converged(mod_cov)) skip()
+  skip_if_not_converged(mod_cov)
   nd_df  <- data.frame(exp_1 = emax_df$exp_1[1:5], cnt_a = emax_df$cnt_a[1:5])
   nd_tbl <- tibble::as_tibble(nd_df)
 
@@ -473,7 +473,7 @@ test_that("confint() falls back to Wald intervals with a warning for sigmoidal m
     covariate_model  = list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1, logHill ~ 1),
     data             = emax_df
   )
-  if (!.is_converged(mod_sig)) skip()
+  skip_if_not_converged(mod_sig)
   # profile CI fails for this sigmoidal logistic model; expect a warning and a valid result
   expect_warning(
     ci <- confint(mod_sig),

--- a/tests/testthat/test-emaxlogistic-printing.R
+++ b/tests/testthat/test-emaxlogistic-printing.R
@@ -22,7 +22,7 @@ mod_bad <- suppressWarnings(emax_logistic(
 # print() -----------------------------------------------------------------
 
 test_that("print() writes expected section headers", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("^Structural model:$", output)))
   expect_true(any(grepl("^Covariate model:$", output)))
@@ -42,13 +42,13 @@ test_that("print() output includes exposure and response names", {
 })
 
 test_that("print() output includes covariate model lines", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("E0.*cnt_a", output)))
 })
 
 test_that("print() includes fit statistics", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("Deviance", output)))
   expect_true(any(grepl("AIC", output)))
@@ -56,7 +56,7 @@ test_that("print() includes fit statistics", {
 })
 
 test_that("print() does not include test statistics or p-values", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_false(any(grepl("z_statistic", output)))
   expect_false(any(grepl("t_statistic", output)))
@@ -64,7 +64,7 @@ test_that("print() does not include test statistics or p-values", {
 })
 
 test_that("print() directs user to summary() for hypothesis tests", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("summary\\(\\)", output)))
 })
@@ -82,26 +82,26 @@ test_that("print() handles non-converged models", {
 # summary() ---------------------------------------------------------------
 
 test_that("summary() returns a data frame", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   expect_s3_class(s, "data.frame")
 })
 
 test_that("summary() has the expected columns", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   expect_named(s, c("label", "estimate", "std_error", "z_statistic",
                     "p_value", "ci_lower", "ci_upper"))
 })
 
 test_that("summary() has one row per parameter", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   expect_equal(nrow(s), length(coef(mod)))
 })
 
 test_that("summary(back_transform = TRUE) transforms log-scaled labels", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod, back_transform = TRUE)
   expect_true("EC50_Intercept" %in% s$label)
   expect_false("logEC50_Intercept" %in% s$label)
@@ -115,7 +115,7 @@ test_that("summary() returns nls_null for non-converged models", {
 # summary(): suppress_nonsensical -----------------------------------------
 
 test_that("summary() suppresses logEC50_Intercept test statistic and p-value by default", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_true(is.na(ec50_row$z_statistic))
@@ -123,7 +123,7 @@ test_that("summary() suppresses logEC50_Intercept test statistic and p-value by 
 })
 
 test_that("summary() still reports CI for logEC50_Intercept when suppressed", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_false(is.na(ec50_row$ci_lower))
@@ -131,7 +131,7 @@ test_that("summary() still reports CI for logEC50_Intercept when suppressed", {
 })
 
 test_that("summary() restores logEC50_Intercept test when suppress_nonsensical = FALSE", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod, suppress_nonsensical = FALSE)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_false(is.na(ec50_row$z_statistic))
@@ -142,14 +142,14 @@ test_that("summary() restores logEC50_Intercept test when suppress_nonsensical =
 # summary(): p_adjust -----------------------------------------------------
 
 test_that("summary() adjusts p-values when p_adjust is set", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s_none <- summary(mod, suppress_nonsensical = FALSE)
   s_bonf <- summary(mod, suppress_nonsensical = FALSE, p_adjust = "bonferroni")
   expect_true(all(s_bonf$p_value >= s_none$p_value))
 })
 
 test_that("summary() p_adjust excludes suppressed p-values from adjustment set", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod, p_adjust = "bonferroni")
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_true(is.na(ec50_row$p_value))
@@ -159,7 +159,7 @@ test_that("summary() p_adjust excludes suppressed p-values from adjustment set",
 # summary(): simultaneous -------------------------------------------------
 
 test_that("summary() simultaneous CIs are wider than pointwise Wald CIs", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   # Both are Wald-based, so the comparison is valid: simultaneous uses a
   # larger critical value from the joint MVN than the pointwise z-quantile.
   s_sim <- summary(mod, simultaneous = TRUE)
@@ -175,7 +175,7 @@ test_that("summary() simultaneous CIs are wider than pointwise Wald CIs", {
 # .coef_table_logistic() --------------------------------------------------
 
 test_that(".coef_table_logistic() returns a data frame with expected structure", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   cc <- .coef_table_logistic(mod)
   expect_s3_class(cc, "data.frame")
   expect_named(cc, c("label", "estimate", "std_error", "z_statistic",
@@ -187,7 +187,7 @@ test_that(".coef_table_logistic() returns a data frame with expected structure",
 # sigmoidal model ---------------------------------------------------------
 
 test_that("sigmoidal: logHill_Intercept is tested and logEC50_Intercept is suppressed", {
-  if (!.is_converged(mod_sig)) skip()
+  skip_if_not_converged(mod_sig)
   s <- suppressWarnings(summary(mod_sig))
 
   hill_row <- s[s$label == "logHill_Intercept", ]

--- a/tests/testthat/test-emaxnls-predict.R
+++ b/tests/testthat/test-emaxnls-predict.R
@@ -5,7 +5,7 @@ mod <- emax_nls(
 )
 
 test_that("predict without se.fit, interval, or newdata returns vector", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   pr_vec <- predict(mod)
   expect_equal(length(pr_vec), nrow(emax_df))
   expect_type(pr_vec, "double")
@@ -14,7 +14,7 @@ test_that("predict without se.fit, interval, or newdata returns vector", {
 })
 
 test_that("predict with se.fit returns list", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   pr_vec <- predict(mod)
   pr_lst <- predict(mod, se.fit = TRUE)
   expect_type(pr_lst, "list")
@@ -27,7 +27,7 @@ test_that("predict with se.fit returns list", {
 })
 
 test_that("predict with interval but not se.fit returns data.frame", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   pr_vec <- predict(mod)
   pr_int <- predict(mod, interval = "confidence")
   expect_s3_class(pr_int, "data.frame")
@@ -40,7 +40,7 @@ test_that("predict with interval but not se.fit returns data.frame", {
 })
 
 test_that("predict with newdata produces expected values", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   ii <- 120:125
   nd <- data.frame(
     exp_1 = emax_df$exp_1[ii], 
@@ -66,7 +66,7 @@ test_that("predict with newdata produces expected values", {
 })
 
 test_that("predict with tibble newdata gives identical results to data.frame", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   nd_df  <- data.frame(exp_1 = emax_df$exp_1[120:125], cnt_a = emax_df$cnt_a[120:125])
   nd_tbl <- tibble::as_tibble(nd_df)
 
@@ -102,7 +102,7 @@ mod <- stats::nls(
 )
 
 test_that(".predict_nls matches default predict method for nls objects", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   
   pred_nls <- c(predict(mod, newdata = new_dat))
   pred_new <- .predict_nls(mod, newdata = new_dat)
@@ -131,7 +131,7 @@ xgx_2 <- list(
 )
 
 test_that(".predict_nls matches xgxr::predict.nls", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   
   prd_1 <- .predict_nls(mod, newdata = new_dat, se.fit = TRUE)
   prd_2 <- .predict_nls(mod, newdata = new_dat, se.fit = TRUE, interval = "confidence")

--- a/tests/testthat/test-emaxnls-printing.R
+++ b/tests/testthat/test-emaxnls-printing.R
@@ -16,7 +16,7 @@ mod_sig <- emax_nls(
 # print() -----------------------------------------------------------------
 
 test_that("print() writes expected section headers and returns object invisibly", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   con <- textConnection("text_connection", "w")
   sink(con)
   val <- print(mod)
@@ -31,14 +31,14 @@ test_that("print() writes expected section headers and returns object invisibly"
 })
 
 test_that("print() does not include test statistics or p-values", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_false(any(grepl("t_statistic", output)))
   expect_false(any(grepl("p_value", output)))
 })
 
 test_that("print() includes fit statistics", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("Observations", output)))
   expect_true(any(grepl("Residual", output)))
@@ -46,7 +46,7 @@ test_that("print() includes fit statistics", {
 })
 
 test_that("print() directs user to summary() for hypothesis tests", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   output <- utils::capture.output(print(mod))
   expect_true(any(grepl("summary\\(\\)", output)))
 })
@@ -55,7 +55,7 @@ test_that("print() directs user to summary() for hypothesis tests", {
 # .coef_table() -----------------------------------------------------------
 
 test_that(".coef_table() returns a data frame with the expected structure", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   cc <- .coef_table(mod)
   expect_s3_class(cc, class = "data.frame")
   expect_named(cc, c("label", "estimate", "std_error", "t_statistic", "p_value",
@@ -67,7 +67,7 @@ test_that(".coef_table() returns a data frame with the expected structure", {
 # summary(): suppress_nonsensical -----------------------------------------
 
 test_that("summary() suppresses logEC50_Intercept test statistic and p-value by default", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_true(is.na(ec50_row$t_statistic))
@@ -75,7 +75,7 @@ test_that("summary() suppresses logEC50_Intercept test statistic and p-value by 
 })
 
 test_that("summary() still reports CI for logEC50_Intercept when suppressed", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_false(is.na(ec50_row$ci_lower))
@@ -83,7 +83,7 @@ test_that("summary() still reports CI for logEC50_Intercept when suppressed", {
 })
 
 test_that("summary() restores logEC50_Intercept test when suppress_nonsensical = FALSE", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s <- summary(mod, suppress_nonsensical = FALSE)
   ec50_row <- s[s$label == "logEC50_Intercept", ]
   expect_false(is.na(ec50_row$t_statistic))
@@ -94,14 +94,14 @@ test_that("summary() restores logEC50_Intercept test when suppress_nonsensical =
 # summary(): p_adjust -----------------------------------------------------
 
 test_that("summary() adjusts p-values when p_adjust is set", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s_none <- summary(mod, suppress_nonsensical = FALSE)
   s_bonf <- summary(mod, suppress_nonsensical = FALSE, p_adjust = "bonferroni")
   expect_true(all(s_bonf$p_value >= s_none$p_value))
 })
 
 test_that("summary() p_adjust excludes suppressed p-values from adjustment set", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   s_none <- summary(mod, p_adjust = "bonferroni")
   # logEC50_Intercept p-value should remain NA even after adjustment
   ec50_row <- s_none[s_none$label == "logEC50_Intercept", ]
@@ -112,7 +112,7 @@ test_that("summary() p_adjust excludes suppressed p-values from adjustment set",
 # summary(): simultaneous -------------------------------------------------
 
 test_that("summary() simultaneous CIs are wider than pointwise Wald CIs", {
-  if (!.is_converged(mod)) skip()
+  skip_if_not_converged(mod)
   # Both are Wald-based, so the comparison is valid: simultaneous uses a
   # larger critical value from the joint MVN than the pointwise t-quantile.
   s_sim  <- summary(mod, simultaneous = TRUE)
@@ -129,7 +129,7 @@ test_that("summary() simultaneous CIs are wider than pointwise Wald CIs", {
 # sigmoidal model ---------------------------------------------------------
 
 test_that("sigmoidal: logHill_Intercept is tested and logEC50_Intercept is suppressed", {
-  if (!.is_converged(mod_sig)) skip()
+  skip_if_not_converged(mod_sig)
   s <- suppressWarnings(summary(mod_sig))
 
   hill_row <- s[s$label == "logHill_Intercept", ]

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -12,7 +12,7 @@ mod_base <- emax_nls(
 )
 
 test_that("methods do not throw errors with basic use", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   expect_no_error(coef(mod))
   expect_no_error(vcov(mod))
   expect_no_error(residuals(mod))
@@ -31,15 +31,15 @@ test_that("methods do not throw errors with basic use", {
 })
 
 test_that("AIC(), BIC(), and anova() can take multiple objects", {
-  if (!.is_converged(mod)) skip_on_ci()
-  if (!.is_converged(mod_base)) skip_on_ci()
+  skip_if_not_converged(mod)
+  skip_if_not_converged(mod_base)
   expect_no_error(AIC(mod_base, mod))
   expect_no_error(BIC(mod_base, mod))
   expect_no_error(anova(mod_base, mod))
 })
 
 test_that("coef() returns numeric vector with correct length and names", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   cc <- coef(mod)
   expect_true(is.vector(cc))
   expect_true(is.numeric(cc))
@@ -48,7 +48,7 @@ test_that("coef() returns numeric vector with correct length and names", {
 })
 
 test_that("vcov() returns symmetric numeric matrix with correct row/col names", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   vv <- vcov(mod)
   expect_true(is.matrix(vv))
   expect_true(is.numeric(vv))
@@ -60,7 +60,7 @@ test_that("vcov() returns symmetric numeric matrix with correct row/col names", 
 })
 
 test_that("residuals() returns numeric vector of the same size as the data", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   rr <- residuals(mod)
   expect_true(is.numeric(rr))
   expect_length(rr, nrow(emax_df))
@@ -95,8 +95,8 @@ test_that("methods return emaxnls_null for models that do not converge", {
 })
 
 test_that("AIC(), BIC(), and anova() handle cases where some models do not converge", {
-  if (!.is_converged(mod)) skip_on_ci()
-  if (!.is_converged(mod_base)) skip_on_ci()
+  skip_if_not_converged(mod)
+  skip_if_not_converged(mod_base)
 
   expect_warning(AIC(mod_base, mod, mod_bad))
   expect_warning(BIC(mod_base, mod, mod_bad))
@@ -108,14 +108,14 @@ test_that("AIC(), BIC(), and anova() handle cases where some models do not conve
 })
 
 test_that("summary() matches .coef_table()", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   expect_equal(summary(mod), .coef_table(mod, suppress_nonsensical = TRUE))
   expect_equal(summary(mod, conf_level = .99), .coef_table(mod, level = .99, suppress_nonsensical = TRUE))
   expect_equal(summary(mod, back_transform = TRUE), .coef_table(mod, back_transform = TRUE, suppress_nonsensical = TRUE))
 })
 
 test_that("back_transform works for confint()", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   ci1 <- confint(mod)
   ci2 <- confint(mod, back_transform = TRUE)
   expect_equal(ci1[-4,], ci2[-4,])
@@ -123,7 +123,7 @@ test_that("back_transform works for confint()", {
 }) 
 
 test_that("back_transform works for coef()", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   cc1 <- coef(mod)
   cc2 <- coef(mod, back_transform = TRUE)
   expect_equal(cc1[-4], cc2[-4])
@@ -131,7 +131,7 @@ test_that("back_transform works for coef()", {
 }) 
 
 test_that("confint(simultaneous = TRUE) matches summary(simultaneous = TRUE)", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   # qmvnorm() uses randomised quasi-Monte Carlo, so the critical value varies
   # slightly between calls; compare with a tolerance rather than exactly.
   ci <- confint(mod, simultaneous = TRUE)
@@ -141,7 +141,7 @@ test_that("confint(simultaneous = TRUE) matches summary(simultaneous = TRUE)", {
 })
 
 test_that("confint(simultaneous = TRUE) gives wider intervals than pointwise", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   ci_sim <- confint(mod, simultaneous = TRUE)
   est    <- stats::coef(mod)
   se     <- sqrt(diag(stats::vcov(mod)))
@@ -151,7 +151,7 @@ test_that("confint(simultaneous = TRUE) gives wider intervals than pointwise", {
 })
 
 test_that("confint(simultaneous = TRUE) respects parm and back_transform", {
-  if (!.is_converged(mod)) skip_on_ci()
+  skip_if_not_converged(mod)
   full <- confint(mod, simultaneous = TRUE)
   parm <- rownames(full)[1:2]
   sub  <- confint(mod, parm = parm, simultaneous = TRUE)
@@ -170,7 +170,7 @@ test_that("confint() falls back to Wald intervals with a warning for sigmoidal m
     covariate_model  = list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1, logHill ~ 1),
     data             = emax_df
   )
-  if (!.is_converged(mod_sig)) skip()
+  skip_if_not_converged(mod_sig)
   # profile CI fails for this sigmoidal model; expect a warning and a valid result
   expect_warning(
     ci <- confint(mod_sig),

--- a/tests/testthat/test-optim-method.R
+++ b/tests/testthat/test-optim-method.R
@@ -32,13 +32,12 @@ test_that("example base model converges with 'gauss'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 test_that("example base model converges with 'port'", {
@@ -69,13 +68,12 @@ test_that("example base model converges with 'port'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 test_that("example base model converges with 'levenberg'", {
@@ -107,13 +105,12 @@ test_that("example base model converges with 'levenberg'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 
@@ -150,13 +147,12 @@ test_that("example covariate model converges with 'gauss'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 test_that("example covariate model converges with 'port'", {
@@ -187,13 +183,12 @@ test_that("example covariate model converges with 'port'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 test_that("example covariate model converges with 'levenberg'", {
@@ -225,13 +220,12 @@ test_that("example covariate model converges with 'levenberg'", {
     data = emax_df,
     opts = emax_nls_options(optim_method = mm)
   )
-  if (.is_converged(mod)) {
-    expect_equal(.get_options(mod)$optim_method, mm)
-    expect_equal(mod$env$algorithm, aa)
-    expect_null(mod$env$error)
-    expect_s3_class(mod$env$model, "nls")
-    expect_true(mod$env$model$convInfo$isConv)
-  }
+  skip_if_not_converged(mod)
+  expect_equal(.get_options(mod)$optim_method, mm)
+  expect_equal(mod$env$algorithm, aa)
+  expect_null(mod$env$error)
+  expect_s3_class(mod$env$model, "nls")
+  expect_true(mod$env$model$convInfo$isConv)
 })
 
 test_that("emax_nls errors for unknown optim_method", {

--- a/tests/testthat/test-scm.R
+++ b/tests/testthat/test-scm.R
@@ -47,12 +47,10 @@ test_that("basic use of forward/backward scm works", {
   skip_if(!.is_converged(mod_0), "Skip if convergence fails on this architecture")
 
   fwd <- .emax_scm_forward(mod = mod_0, candidates = cov_list_big, threshold = .01)
-  if (.is_converged(fwd)) {
-    bck <- .emax_scm_backward(mod = fwd, candidates = cov_list_big, threshold = .001)
-    if (.is_converged(bck)) {
-      expect_equal(sort(.get_coefficient_names(bck)), sort(.get_coefficient_names(mod_1))) # should find the E0 ~ cnt_a term only
-    }
-  }
+  skip_if_not_converged(fwd)
+  bck <- .emax_scm_backward(mod = fwd, candidates = cov_list_big, threshold = .001)
+  skip_if_not_converged(bck)
+  expect_equal(sort(.get_coefficient_names(bck)), sort(.get_coefficient_names(mod_1))) # should find the E0 ~ cnt_a term only
 })
 
 test_that("scm stores history in mod$info", {
@@ -61,18 +59,16 @@ test_that("scm stores history in mod$info", {
   expect_true(is.null(mod_0$info$history))
 
   fwd <- .emax_scm_forward(mod = mod_0, candidates = cov_list_big, threshold = .01)
-  if (.is_converged(fwd)) {
-    expect_true(!is.null(fwd$info$history))
-    h_fwd <- fwd$info$history
-    expect_true(inherits(h_fwd, "data.frame"))
+  skip_if_not_converged(fwd)
+  expect_true(!is.null(fwd$info$history))
+  h_fwd <- fwd$info$history
+  expect_true(inherits(h_fwd, "data.frame"))
 
-    bck <- .emax_scm_backward(mod = fwd, candidates = cov_list_big, threshold = .001)
-    if (.is_converged(bck)) {
-      expect_true(!is.null(bck$info$history))
-      h_bck <- bck$info$history
-      expect_true(inherits(h_bck, "data.frame"))
-      expect_equal(.filter(h_bck, step != "backward"), h_fwd)
-    }
-  }
+  bck <- .emax_scm_backward(mod = fwd, candidates = cov_list_big, threshold = .001)
+  skip_if_not_converged(bck)
+  expect_true(!is.null(bck$info$history))
+  h_bck <- bck$info$history
+  expect_true(inherits(h_bck, "data.frame"))
+  expect_equal(.filter(h_bck, step != "backward"), h_fwd)
 })
 


### PR DESCRIPTION
Closes #55

## Summary

Addresses the four problems described in the issue:

**1. Missing skip reasons**
Many tests guarded with `if (!.is_converged(mod)) skip()` provided no skip reason, making CI output harder to diagnose.

**2. Wrong skip function (`skip_on_ci()`)**
Several tests in `test-methods.R` and `test-emaxnls-predict.R` used `if (!.is_converged(mod)) skip_on_ci()`. This skips on all CI (not just architectures with convergence issues) and silently runs a potentially-broken test locally when convergence fails.

**3. Vacuous `if (.is_converged(mod)) { }` blocks**
Six tests in `test-optim-method.R` and two compound blocks in `test-scm.R` wrapped their assertions in `if (.is_converged(mod)) { }`. On platforms where convergence unexpectedly fails these tests pass with no assertions executed.

**4. Stale inline comments**
`test-emaxlogistic-class.R` contained comments acknowledging the problem (`# not ideal in this case`, `# again, not ideal here`) that are now resolved.

## Changes

- Adds `skip_if_not_converged()` helper to `helper-platform.R` as a single call site with a consistent message: `"Skip: model did not converge on this architecture"`.
- Replaces all `if (!.is_converged(...)) skip()` and `if (!.is_converged(...)) skip_on_ci()` calls with `skip_if_not_converged()`.
- Unwraps all `if (.is_converged(mod)) { assertions }` blocks into `skip_if_not_converged(mod)` followed by unconditional assertions.

## Scope

Only test infrastructure is changed — no changes to package source code. `test-emaxnls-class.R`, `test-api.R`, and `test-data.R` were reviewed and confirmed to need no changes.