### PR TITLE
fix: reconstruct named start/lower/upper vectors from parameter/covariate columns

### DIFF
--- a/R/emaxlogistic-init.R
+++ b/R/emaxlogistic-init.R
@@ -65,10 +65,6 @@
     covariate != "Intercept" & parameter == "logHill" ~ loghill_max
   ))
 
-  names(ini$start) <- coefficient_vec
-  names(ini$lower) <- coefficient_vec
-  names(ini$upper) <- coefficient_vec
-
   return(ini)
 }
 

--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -123,11 +123,11 @@
     data = list(
       formula   = obj$formula$expanded,
       design    = obj$info$design,
-      start     = setNames(init$start, coef_nms),
+      start     = stats::setNames(init$start, coef_nms),
       control   = obj$info$opts$optim_control,
       algorithm = .nls_method(obj$info$opts$optim_method),
-      lower     = setNames(init$lower, coef_nms),
-      upper     = setNames(init$upper, coef_nms),
+      lower     = stats::setNames(init$lower, coef_nms),
+      upper     = stats::setNames(init$upper, coef_nms),
       weights   = obj$info$opts$weights
     ),
     parent = parent.frame()

--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -111,17 +111,25 @@
 # is that everything you need to construct env should be elsewhere
 # in the model object
 .construct_env <- function(obj) {
+  # Reconstruct named vectors from the parameter/covariate columns rather than
+  # relying on element names surviving data.frame column storage. Base R
+  # data.frame silently strips element names from numeric columns, so any names
+  # set on init$start/lower/upper at construction time are lost when tibble is
+  # unavailable. The parameter and covariate columns always encode this
+  # information reliably. See issue #57.
+  init    <- obj$info$init
+  coef_nms <- paste(init$parameter, init$covariate, sep = "_")
   rlang::new_environment(
     data = list(
-      formula   = obj$formula$expanded, 
-      design    = obj$info$design, 
-      start     = obj$info$init$start, 
-      control   = obj$info$opts$optim_control, 
-      algorithm = .nls_method(obj$info$opts$optim_method), 
-      lower     = obj$info$init$lower,
-      upper     = obj$info$init$upper,
+      formula   = obj$formula$expanded,
+      design    = obj$info$design,
+      start     = setNames(init$start, coef_nms),
+      control   = obj$info$opts$optim_control,
+      algorithm = .nls_method(obj$info$opts$optim_method),
+      lower     = setNames(init$lower, coef_nms),
+      upper     = setNames(init$upper, coef_nms),
       weights   = obj$info$opts$weights
-    ), 
+    ),
     parent = parent.frame()
   )
 }

--- a/R/emaxnls-init.R
+++ b/R/emaxnls-init.R
@@ -62,10 +62,6 @@
     covariate != "Intercept" & parameter == "logHill" ~ loghill_max
   ))
       
-  names(ini$start) <- coefficient_vec
-  names(ini$lower) <- coefficient_vec
-  names(ini$upper) <- coefficient_vec
-
   return(ini)
 }
 

--- a/tests/testthat/test-emaxlogistic-init.R
+++ b/tests/testthat/test-emaxlogistic-init.R
@@ -22,14 +22,18 @@ test_that("emax_logistic_init() start values are within lower/upper bounds", {
   expect_true(all(init$start <= init$upper))
 })
 
-test_that("emax_logistic_init() start values are named correctly", {
+test_that("emax_logistic_init() parameter and covariate columns encode correct names", {
+  # The coefficient names are encoded in the parameter and covariate columns.
+  # Base R data.frame strips element names from numeric columns, so we cannot
+  # rely on names(init$start); the parameter/covariate columns are the
+  # authoritative source. See issue #57.
   init <- emax_logistic_init(
     structural_model = rsp_2 ~ exp_1,
     covariate_model  = list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1),
     data             = emax_df
   )
   coef_names <- paste(init$parameter, init$covariate, sep = "_")
-  expect_equal(names(init$start), coef_names)
+  expect_equal(coef_names, c("E0_Intercept", "Emax_Intercept", "logEC50_Intercept"))
 })
 
 test_that("emax_logistic_init() handles sigmoidal models", {
@@ -39,8 +43,9 @@ test_that("emax_logistic_init() handles sigmoidal models", {
     data             = emax_df
   )
   expect_equal(nrow(init), 4L)
-  expect_true("logHill_Intercept" %in% names(init$start))
-  expect_equal(init$start["logHill_Intercept"], 0, ignore_attr = TRUE)
+  loghill_row <- init[init$parameter == "logHill" & init$covariate == "Intercept", ]
+  expect_equal(nrow(loghill_row), 1L)
+  expect_equal(loghill_row$start, 0)
 })
 
 test_that("emax_logistic_init() validates inputs", {

--- a/tests/testthat/test-emaxnls-guess.R
+++ b/tests/testthat/test-emaxnls-guess.R
@@ -26,6 +26,31 @@ test_that(".emax_nls_init returns expected data frame", {
   }
 })
 
+test_that(".emax_nls_init parameter and covariate columns encode correct names", {
+  # The coefficient names are encoded in the parameter and covariate columns.
+  # Base R data.frame strips element names from numeric columns, so the
+  # parameter/covariate columns are the authoritative source. See issue #57.
+  gg <- .emax_nls_init(
+    rsp_1 ~ exp_1,
+    list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1),
+    emax_df
+  )
+  coef_names <- paste(gg$parameter, gg$covariate, sep = "_")
+  expect_equal(coef_names, c("E0_Intercept", "Emax_Intercept", "logEC50_Intercept"))
+})
+
+test_that(".emax_nls_init handles sigmoidal models: logHill row present with start = 0", {
+  gg <- .emax_nls_init(
+    rsp_1 ~ exp_1,
+    list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1, logHill ~ 1),
+    emax_df
+  )
+  expect_equal(nrow(gg), 4L)
+  loghill_row <- gg[gg$parameter == "logHill" & gg$covariate == "Intercept", ]
+  expect_equal(nrow(loghill_row), 1L)
+  expect_equal(loghill_row$start, 0)
+})
+
 test_that(".guess_init scales logEC50 with exposure", {
 
   gg1 <- .emax_nls_init(str_model, cov_model, dfs$unmodified)


### PR DESCRIPTION
Closes #57.

## Problem

Base R `data.frame` silently strips element names from numeric column vectors on assignment. Both `.guess_init()` and `.guess_init_logistic()` ended with:

```r
names(ini$start) <- coefficient_vec
names(ini$lower) <- coefficient_vec
names(ini$upper) <- coefficient_vec
```

These lines are no-ops for a base `data.frame`. They appeared to work locally only because tibble (which preserves column element names) was available, and `.tibble()` chose the tibble path. On rhub builders where tibble's shared object fails to link at runtime, `.tibble()` falls back to `as.data.frame()` and the names are silently lost.

This caused two separate failures:

**3 test FAILs** in `test-emaxlogistic-init.R`: the tests checked `names(init$start)` directly; with a base `data.frame` this is always `NULL`.

**100+ test SKIPs** across the rest of the suite: `.construct_env()` passed the now-unnamed `start` vector to `nls()`, which errors with `parameters without starting value in 'data'`. The `.nls_safe()` wrapper caught this as a convergence failure, so every downstream model-fitting test was skipped via `skip_if_not_converged()`. The root cause was invisible — it looked like an architecture-specific convergence problem rather than a broken init path.

The identical bug existed in `emaxnls-init.R` but was undetected because `test-emaxnls-guess.R` never checked `names(gg$start)`.

## Fix

**`R/emaxlogistic-init.R` and `R/emaxnls-init.R`** — remove the dead `names(ini$*)` assignments. The `parameter` and `covariate` columns already encode all the information reliably.

**`R/emaxnls-class.R` — `.construct_env()`** — reconstruct named vectors explicitly from those columns rather than trusting element names to survive data.frame storage:

```r
coef_nms <- paste(init$parameter, init$covariate, sep = "_")
start     = setNames(init$start, coef_nms),
lower     = setNames(init$lower, coef_nms),
upper     = setNames(init$upper, coef_nms),
```

**`tests/testthat/test-emaxlogistic-init.R`** — rewrite the two previously-failing tests to assert the `parameter`/`covariate` columns directly, and use row-based indexing for the sigmoidal `logHill` value check.

**`tests/testthat/test-emaxnls-guess.R`** — add a symmetric names test and a sigmoidal-row test to cover the same invariants for the NLS path.

## Results

`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 658 ]` locally (up from 655 passing tests before; 3 new tests added).