### PR TITLE
feat: add max_time option to emax_nls_options() and emax_logistic_opt…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@
 
 ## New features
 
+* Adds a `max_time` argument to `emax_nls_options()` and
+  `emax_logistic_options()` that sets a maximum elapsed time (in seconds) for
+  model fitting. If the optimizer has not converged within the limit it is
+  terminated and the model is treated as non-converged, consistent with any
+  other convergence failure. Defaults to `Inf` (no limit). This is particularly
+  useful when running many models in an SCM procedure, where a single
+  pathological fit can otherwise stall the entire covariate search (#16).
+
 * Adds `emax_logistic()` for fitting binary-outcome Emax models using iterative
   reweighted least squares (IRLS), along with `emax_logistic_init()` and
   `emax_logistic_options()` for initialization and configuration. All standard

--- a/R/api.R
+++ b/R/api.R
@@ -71,6 +71,10 @@ emax_nls <- function(structural_model,
 #' @param weights Numeric vector providing the weights for observations. When
 #' specified, weighted least squares is used
 #' @param na.action How should missing values in the data be handled?
+#' @param max_time Maximum elapsed time in seconds allowed for the model fit.
+#' If the optimizer has not converged within this time, it is terminated and
+#' the model is treated as non-converged (the same outcome as any other
+#' convergence failure). Defaults to `Inf` (no time limit).
 #'
 #' @details
 #' At present there are three supported values for `optim_method`:
@@ -111,13 +115,15 @@ emax_nls_options <- function(optim_method = "gauss",
                              optim_control = NULL,
                              quiet = FALSE,
                              weights = NULL,
-                             na.action = getOption("na.action")) {
+                             na.action = getOption("na.action"),
+                             max_time = Inf) {
   .emax_nls_options(
     optim_method = optim_method,
     optim_control = optim_control,
     quiet = quiet,
     weights = weights,
-    na.action = na.action
+    na.action = na.action,
+    max_time = max_time
   )
 }
 
@@ -488,6 +494,10 @@ emax_logistic <- function(structural_model,
 #' @param max_iter Maximum number of IRLS outer iterations (default 25).
 #' @param tol Convergence tolerance: IRLS stops when the change in binomial
 #' deviance between successive iterations falls below `tol` (default 1e-6).
+#' @param max_time Maximum elapsed time in seconds allowed for the entire model
+#' fit (including all IRLS iterations). If the optimizer has not converged
+#' within this time, it is terminated and the model is treated as
+#' non-converged. Defaults to `Inf` (no time limit).
 #'
 #' @returns A list of settings
 #'
@@ -506,14 +516,16 @@ emax_logistic_options <- function(optim_method = "gauss",
                                   quiet = FALSE,
                                   na.action = getOption("na.action"),
                                   max_iter = 25,
-                                  tol = 1e-6) {
+                                  tol = 1e-6,
+                                  max_time = Inf) {
   .emax_logistic_options(
     optim_method  = optim_method,
     optim_control = optim_control,
     quiet         = quiet,
     na.action     = na.action,
     max_iter      = max_iter,
-    tol           = tol
+    tol           = tol,
+    max_time      = max_time
   )
 }
 

--- a/R/emaxlogistic-class.R
+++ b/R/emaxlogistic-class.R
@@ -39,8 +39,25 @@
   obj$formula$expanded <- .construct_expanded_formula(obj$info$variables)
   obj$env <- .construct_env(obj)
 
+  # Apply elapsed time limit if requested. The on.exit() reset ensures the
+  # limit is cleared when this function returns normally (without a timeout).
+  # The tryCatch around .irls_loop() handles the edge case where a timeout
+  # fires in IRLS bookkeeping code between NLS calls (rather than inside
+  # nls() itself, which is already caught by .nls_safe()).
+  if (is.finite(opts$max_time)) {
+    on.exit(setTimeLimit(elapsed = Inf), add = TRUE)
+    setTimeLimit(elapsed = opts$max_time, transient = TRUE)
+  }
+
   # run IRLS
-  irls_out <- .irls_loop(obj, opts)
+  irls_out <- tryCatch(
+    .irls_loop(obj, opts),
+    error = function(e) list(
+      result = NULL,
+      error  = e,
+      irls   = list(iter = NA_integer_, converged = FALSE)
+    )
+  )
 
   # store results
   obj$env$model <- irls_out$result

--- a/R/emaxlogistic-options.R
+++ b/R/emaxlogistic-options.R
@@ -4,9 +4,11 @@
                                    quiet,
                                    na.action,
                                    max_iter,
-                                   tol) {
+                                   tol,
+                                   max_time) {
 
   .validate_optim_method(optim_method)
+  .validate_max_time(max_time)
 
   if (is.null(optim_control)) {
     if (optim_method == "gauss") optim_control <- stats::nls.control()
@@ -24,7 +26,8 @@
     weights = NULL,   # always NULL for logistic; computed internally by IRLS
     na.action = na.action,
     max_iter = max_iter,
-    tol = tol
+    tol = tol,
+    max_time = max_time
   )
   return(opts)
 }

--- a/R/emaxnls-class.R
+++ b/R/emaxnls-class.R
@@ -37,6 +37,14 @@
   obj$env <- .construct_env(obj)
 
 
+  # Apply elapsed time limit if requested. The on.exit() reset ensures the
+  # limit is cleared when this function returns normally (without a timeout),
+  # because setTimeLimit() with transient = TRUE only auto-clears on timeout.
+  if (is.finite(opts$max_time)) {
+    on.exit(setTimeLimit(elapsed = Inf), add = TRUE)
+    setTimeLimit(elapsed = opts$max_time, transient = TRUE)
+  }
+
   # estimate the nls model
   tmp <- evalq(
     .nls_call(

--- a/R/emaxnls-options.R
+++ b/R/emaxnls-options.R
@@ -2,10 +2,12 @@
                               optim_control, 
                               quiet, 
                               weights, 
-                              na.action) {
+                              na.action,
+                              max_time) {
   
   .validate_optim_method(optim_method)
-  
+  .validate_max_time(max_time)
+
   if (is.null(optim_control)) {
     if (optim_method == "gauss") optim_control <- stats::nls.control()  
     if (optim_method == "port") optim_control <- stats::nls.control()
@@ -20,7 +22,8 @@
     optim_control = optim_control,
     quiet = quiet,
     weights = weights,
-    na.action = na.action
+    na.action = na.action,
+    max_time = max_time
   )
   return(opts)
 }

--- a/R/utils-validators.R
+++ b/R/utils-validators.R
@@ -47,6 +47,13 @@
 
 }
 
+.validate_max_time <- function(max_time) {
+  .assert(
+    .is_scalar_num(max_time) && max_time > 0,
+    "`max_time` must be a single positive number (use `Inf` for no time limit)"
+  )
+}
+
 .validate_optim_method <- function(optim_method) {
   .assert(
     expr = optim_method %in% c("gauss", "port", "levenberg"),

--- a/man/emax_logistic_options.Rd
+++ b/man/emax_logistic_options.Rd
@@ -10,7 +10,8 @@ emax_logistic_options(
   quiet = FALSE,
   na.action = getOption("na.action"),
   max_iter = 25,
-  tol = 1e-06
+  tol = 1e-06,
+  max_time = Inf
 )
 }
 \arguments{
@@ -29,6 +30,11 @@ for details on each.}
 
 \item{tol}{Convergence tolerance: IRLS stops when the change in binomial
 deviance between successive iterations falls below \code{tol} (default 1e-6).}
+
+\item{max_time}{Maximum elapsed time in seconds allowed for the entire model
+fit (including all IRLS iterations). If the optimizer has not converged
+within this time, it is terminated and the model is treated as
+non-converged. Defaults to \code{Inf} (no time limit).}
 }
 \value{
 A list of settings

--- a/man/emax_nls_options.Rd
+++ b/man/emax_nls_options.Rd
@@ -9,7 +9,8 @@ emax_nls_options(
   optim_control = NULL,
   quiet = FALSE,
   weights = NULL,
-  na.action = getOption("na.action")
+  na.action = getOption("na.action"),
+  max_time = Inf
 )
 }
 \arguments{
@@ -27,6 +28,11 @@ algorithm is used}
 specified, weighted least squares is used}
 
 \item{na.action}{How should missing values in the data be handled?}
+
+\item{max_time}{Maximum elapsed time in seconds allowed for the model fit.
+If the optimizer has not converged within this time, it is terminated and
+the model is treated as non-converged (the same outcome as any other
+convergence failure). Defaults to \code{Inf} (no time limit).}
 }
 \value{
 A list of settings

--- a/tests/testthat/test-max-time.R
+++ b/tests/testthat/test-max-time.R
@@ -1,0 +1,156 @@
+
+# Tests for the max_time option in emax_nls_options() and emax_logistic_options()
+
+str_mod <- rsp_1 ~ exp_1
+cov_mod <- list(E0 ~ 1, Emax ~ 1, logEC50 ~ 1)
+
+
+# --- options storage ---------------------------------------------------------
+
+test_that("emax_nls_options() stores max_time = Inf by default", {
+  opts <- emax_nls_options()
+  expect_equal(opts$max_time, Inf)
+})
+
+test_that("emax_nls_options() stores a finite max_time correctly", {
+  opts <- emax_nls_options(max_time = 10)
+  expect_equal(opts$max_time, 10)
+})
+
+test_that("emax_logistic_options() stores max_time = Inf by default", {
+  opts <- emax_logistic_options()
+  expect_equal(opts$max_time, Inf)
+})
+
+test_that("emax_logistic_options() stores a finite max_time correctly", {
+  opts <- emax_logistic_options(max_time = 10)
+  expect_equal(opts$max_time, 10)
+})
+
+test_that("emax_nls_options() rejects invalid max_time values", {
+  expect_error(emax_nls_options(max_time = -1),    class = "emaxnls_error")
+  expect_error(emax_nls_options(max_time = 0),     class = "emaxnls_error")
+  expect_error(emax_nls_options(max_time = "10"),  class = "emaxnls_error")
+  expect_error(emax_nls_options(max_time = c(1, 2)), class = "emaxnls_error")
+})
+
+test_that("emax_logistic_options() rejects invalid max_time values", {
+  expect_error(emax_logistic_options(max_time = -1),    class = "emaxnls_error")
+  expect_error(emax_logistic_options(max_time = 0),     class = "emaxnls_error")
+  expect_error(emax_logistic_options(max_time = "10"),  class = "emaxnls_error")
+  expect_error(emax_logistic_options(max_time = c(1, 2)), class = "emaxnls_error")
+})
+
+
+# --- max_time stored in fitted model -----------------------------------------
+
+test_that("max_time is stored in the fitted emax_nls model options", {
+  mod <- suppressWarnings(emax_nls(
+    structural_model = str_mod,
+    covariate_model  = cov_mod,
+    data             = emax_df,
+    opts             = emax_nls_options(max_time = 30)
+  ))
+  expect_equal(.get_options(mod)$max_time, 30)
+})
+
+test_that("max_time is stored in the fitted emax_logistic model options", {
+  mod <- suppressWarnings(emax_logistic(
+    structural_model = rsp_2 ~ exp_1,
+    covariate_model  = cov_mod,
+    data             = emax_df,
+    opts             = emax_logistic_options(max_time = 30)
+  ))
+  expect_equal(.get_options(mod)$max_time, 30)
+})
+
+
+# --- timeout causes non-convergence ------------------------------------------
+#
+# R's setTimeLimit() checking happens at user interrupt check points, which are
+# frequent in R-level code but tied to system timer granularity (~5-10ms). We
+# use a large dataset to ensure the fit genuinely exceeds the time limit, and
+# max_time = 0.05 (50ms) to sit well above the timer resolution floor.
+
+# helper: replicate emax_df to a size that makes fits reliably slow (> 400ms)
+make_slow_data <- function() {
+  do.call(rbind, replicate(500, emax_df, simplify = FALSE))
+}
+
+test_that("emax_nls() treats a timeout as non-convergence", {
+  skip_on_cran()
+  mod <- suppressWarnings(emax_nls(
+    structural_model = str_mod,
+    covariate_model  = cov_mod,
+    data             = make_slow_data(),
+    opts             = emax_nls_options(max_time = 0.05)
+  ))
+  expect_s3_class(mod, "emaxnls")
+  expect_false(emax_converged(mod))
+  expect_match(conditionMessage(mod$env$error), "time limit", ignore.case = TRUE)
+})
+
+test_that("emax_logistic() treats a timeout as non-convergence", {
+  skip_on_cran()
+  mod <- suppressWarnings(emax_logistic(
+    structural_model = rsp_2 ~ exp_1,
+    covariate_model  = cov_mod,
+    data             = make_slow_data(),
+    opts             = emax_logistic_options(max_time = 0.05)
+  ))
+  expect_s3_class(mod, "emaxlogistic")
+  expect_false(emax_converged(mod))
+  expect_match(conditionMessage(mod$env$error), "time limit", ignore.case = TRUE)
+})
+
+
+# --- time limit reset after fitting ------------------------------------------
+#
+# A finite max_time must not leave an active time limit in the session after
+# the function returns, whether the fit completed normally or timed out. This
+# matters especially in SCM loops where emax_nls() is called many times.
+
+test_that("emax_nls() resets the time limit to Inf on normal exit", {
+  skip_on_cran()
+  suppressWarnings(emax_nls(
+    structural_model = str_mod,
+    covariate_model  = cov_mod,
+    data             = emax_df,
+    opts             = emax_nls_options(max_time = 30)
+  ))
+  # After return, Sys.sleep() must not trigger a time-limit error
+  expect_no_error(Sys.sleep(0.01))
+})
+
+test_that("emax_nls() resets the time limit to Inf after a timeout", {
+  skip_on_cran()
+  suppressWarnings(emax_nls(
+    structural_model = str_mod,
+    covariate_model  = cov_mod,
+    data             = make_slow_data(),
+    opts             = emax_nls_options(max_time = 0.05)
+  ))
+  expect_no_error(Sys.sleep(0.01))
+})
+
+test_that("emax_logistic() resets the time limit to Inf on normal exit", {
+  skip_on_cran()
+  suppressWarnings(emax_logistic(
+    structural_model = rsp_2 ~ exp_1,
+    covariate_model  = cov_mod,
+    data             = emax_df,
+    opts             = emax_logistic_options(max_time = 30)
+  ))
+  expect_no_error(Sys.sleep(0.01))
+})
+
+test_that("emax_logistic() resets the time limit to Inf after a timeout", {
+  skip_on_cran()
+  suppressWarnings(emax_logistic(
+    structural_model = rsp_2 ~ exp_1,
+    covariate_model  = cov_mod,
+    data             = make_slow_data(),
+    opts             = emax_logistic_options(max_time = 0.05)
+  ))
+  expect_no_error(Sys.sleep(0.01))
+})


### PR DESCRIPTION
…ions()

Closes #16

Adds a max_time argument (default Inf) to both emax_nls_options() and emax_logistic_options() that terminates model fitting if the elapsed time exceeds the specified limit. A timed-out fit is treated as non-convergence, consistent with any other optimizer failure.

Implementation details:
- setTimeLimit(elapsed = max_time, transient = TRUE) is called just before the optimizer in both .emax_nls() and .emax_logistic()
- on.exit(setTimeLimit(elapsed = Inf)) resets the limit on normal return, preventing leakage into subsequent calls (e.g. SCM loops)
- For emax_logistic, a tryCatch wraps .irls_loop() to catch the edge case where a timeout fires in IRLS bookkeeping code between NLS calls
- .validate_max_time() added to utils-validators.R

Tests added in tests/testthat/test-max-time.R covering:
- Default value storage (Inf)
- Custom value storage
- Input validation (negative, zero, non-numeric, length > 1)
- max_time stored in fitted model opts
- Timeout causes non-convergence with expected error message
- Time limit is reset to Inf after both normal exit and timeout